### PR TITLE
Add `sourcebuilder` package.

### DIFF
--- a/cmd/gritd/internal/deps/source.go
+++ b/cmd/gritd/internal/deps/source.go
@@ -3,7 +3,7 @@ package deps
 import (
 	"github.com/dogmatiq/dodeca/logging"
 	"github.com/gritcli/grit/cmd/gritd/internal/source"
-	"github.com/gritcli/grit/cmd/gritd/internal/source/github"
+	"github.com/gritcli/grit/cmd/gritd/internal/source/sourcebuilder"
 	"github.com/gritcli/grit/internal/config"
 )
 
@@ -11,48 +11,11 @@ func init() {
 	Container.Provide(func(
 		cfg config.Config,
 		logger logging.Logger,
-	) ([]source.Source, error) {
-		var sources []source.Source
-
-		factory := sourceFactory{
+	) []source.Source {
+		builder := &sourcebuilder.Builder{
 			Logger: logger,
 		}
 
-		for _, c := range cfg.Sources {
-			c.AcceptVisitor(&factory)
-
-			if factory.Error != nil {
-				return nil, factory.Error
-			}
-
-			sources = append(sources, factory.Source)
-		}
-
-		return sources, nil
+		return builder.FromConfig(cfg)
 	})
-}
-
-// sourceFactory constructs source.Source instances from config.Source values.
-type sourceFactory struct {
-	Logger logging.Logger
-	Source source.Source
-	Error  error
-}
-
-func (f *sourceFactory) VisitGitHubSource(s config.Source, cfg config.GitHub) {
-	d, err := github.NewDriver(
-		cfg,
-		logging.Prefix(f.Logger, "source[%s]: ", s.Name),
-	)
-
-	if err != nil {
-		f.Error = err
-		return
-	}
-
-	f.Source = source.Source{
-		Name:        s.Name,
-		Description: cfg.String(),
-		Driver:      d,
-	}
 }

--- a/cmd/gritd/internal/source/github/clone.go
+++ b/cmd/gritd/internal/source/github/clone.go
@@ -13,12 +13,12 @@ import (
 )
 
 // Clone makes a repository available at the specified directory.
-func (d *driver) Clone(
+func (d *Driver) Clone(
 	ctx context.Context,
 	repoID, tempDir string,
 	clientLog logging.Logger,
 ) (string, error) {
-	serverLog := logging.Prefix(d.logger, "clone[%s]: ", repoID)
+	serverLog := logging.Prefix(d.Logger, "clone[%s]: ", repoID)
 
 	id, err := parseRepoID(repoID)
 	if err != nil {
@@ -39,7 +39,7 @@ func (d *driver) Clone(
 	logging.Debug(serverLog, "cloning %s to %s", r.GetFullName(), tempDir)
 
 	opts, err := newCloneOptions(
-		d.cfg,
+		d.Config,
 		r,
 		logging.Tee(
 			logging.Demote(serverLog), // log to the server as debug

--- a/cmd/gritd/internal/source/github/driver_test.go
+++ b/cmd/gritd/internal/source/github/driver_test.go
@@ -132,13 +132,14 @@ func initDriver(cfg func() config.GitHub, configure []func(*config.GitHub)) (con
 		fn(&c)
 	}
 
-	d, err := NewDriver(c, logging.SilentLogger)
-	Expect(err).ShouldNot(HaveOccurred())
+	d := &Driver{
+		Config: c,
+		Logger: logging.SilentLogger,
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	err = d.Init(ctx)
-	if err != nil {
+	if err := d.Init(ctx); err != nil {
 		cancel()
 		skipIfRateLimited(err)
 	}

--- a/cmd/gritd/internal/source/github/resolve.go
+++ b/cmd/gritd/internal/source/github/resolve.go
@@ -10,12 +10,12 @@ import (
 
 // Resolve resolves a repository name, URL, or other identifier to a set of
 // possible repositories.
-func (d *driver) Resolve(
+func (d *Driver) Resolve(
 	ctx context.Context,
 	query string,
 	clientLog logging.Logger,
 ) ([]source.Repo, error) {
-	serverLog := logging.Prefix(d.logger, "resolve[%s]: ", query)
+	serverLog := logging.Prefix(d.Logger, "resolve[%s]: ", query)
 	clientLog = logging.Tee(serverLog, clientLog) // log everything sent to the client on the server as well
 
 	ownerName, repoName, err := parseRepoName(query)

--- a/cmd/gritd/internal/source/sourcebuilder/builder.go
+++ b/cmd/gritd/internal/source/sourcebuilder/builder.go
@@ -1,0 +1,61 @@
+package sourcebuilder
+
+import (
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/gritcli/grit/cmd/gritd/internal/source"
+	"github.com/gritcli/grit/cmd/gritd/internal/source/github"
+	"github.com/gritcli/grit/internal/config"
+)
+
+// Builder builds source.Source values from Grit configuration.
+type Builder struct {
+	// Logger is the target for log messages from source drivers.
+	Logger logging.Logger
+}
+
+// FromConfig returns the list of sources defined in cfg.
+func (b *Builder) FromConfig(cfg config.Config) []source.Source {
+	var sources []source.Source
+
+	for _, cfg := range cfg.Sources {
+		src := b.FromSourceConfig(cfg)
+		sources = append(sources, src)
+	}
+
+	return sources
+}
+
+// FromSourceConfig returns the Source defined in cfg.
+func (b *Builder) FromSourceConfig(cfg config.Source) source.Source {
+	f := &driverFactory{
+		Logger: logging.Prefix(
+			b.Logger,
+			"source[%s]: ",
+			cfg.Name,
+		),
+	}
+
+	cfg.AcceptVisitor(f)
+
+	return source.Source{
+		Name:        cfg.Name,
+		Description: cfg.DriverConfig.String(),
+		Driver:      f.Driver,
+	}
+}
+
+// driverFactory is a config.SourceVisitor implementation that constructs
+// drivers based on source configurations.
+type driverFactory struct {
+	Logger logging.Logger
+	Driver source.Driver
+}
+
+func (f *driverFactory) VisitGitHubSource(s config.Source, cfg config.GitHub) {
+	d, err := github.NewDriver(cfg, f.Logger)
+	if err != nil {
+		panic(err)
+	}
+
+	f.Driver = d
+}

--- a/cmd/gritd/internal/source/sourcebuilder/builder.go
+++ b/cmd/gritd/internal/source/sourcebuilder/builder.go
@@ -13,13 +13,15 @@ type Builder struct {
 	Logger logging.Logger
 }
 
-// FromConfig returns the list of sources defined in cfg.
+// FromConfig returns the list of enabled sources defined in cfg.
 func (b *Builder) FromConfig(cfg config.Config) []source.Source {
 	var sources []source.Source
 
 	for _, cfg := range cfg.Sources {
-		src := b.FromSourceConfig(cfg)
-		sources = append(sources, src)
+		if cfg.Enabled {
+			src := b.FromSourceConfig(cfg)
+			sources = append(sources, src)
+		}
 	}
 
 	return sources

--- a/cmd/gritd/internal/source/sourcebuilder/builder.go
+++ b/cmd/gritd/internal/source/sourcebuilder/builder.go
@@ -47,15 +47,13 @@ func (b *Builder) FromSourceConfig(cfg config.Source) source.Source {
 // driverFactory is a config.SourceVisitor implementation that constructs
 // drivers based on source configurations.
 type driverFactory struct {
-	Logger logging.Logger
 	Driver source.Driver
+	Logger logging.Logger
 }
 
 func (f *driverFactory) VisitGitHubSource(s config.Source, cfg config.GitHub) {
-	d, err := github.NewDriver(cfg, f.Logger)
-	if err != nil {
-		panic(err)
+	f.Driver = &github.Driver{
+		Config: cfg,
+		Logger: f.Logger,
 	}
-
-	f.Driver = d
 }

--- a/cmd/gritd/internal/source/sourcebuilder/builder_test.go
+++ b/cmd/gritd/internal/source/sourcebuilder/builder_test.go
@@ -1,0 +1,60 @@
+package sourcebuilder_test
+
+import (
+	"github.com/dogmatiq/dodeca/logging"
+	"github.com/gritcli/grit/cmd/gritd/internal/source"
+	"github.com/gritcli/grit/cmd/gritd/internal/source/github"
+	. "github.com/gritcli/grit/cmd/gritd/internal/source/sourcebuilder"
+	"github.com/gritcli/grit/internal/config"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func Listen()", func() {
+	var (
+		logger  logging.BufferedLogger
+		builder *Builder
+	)
+
+	BeforeEach(func() {
+		logger.Reset()
+
+		builder = &Builder{
+			Logger: &logger,
+		}
+	})
+
+	Describe("func FromSourceConfig()", func() {
+		table.DescribeTable(
+			"it constructs sources based on the driver configuration type",
+			func(cfg config.Source, expect source.Source) {
+				src := builder.FromSourceConfig(cfg)
+				Expect(src).To(Equal(expect))
+			},
+			Entry(
+				"github",
+				config.Source{
+					Name: "test-source",
+					Clones: config.Clones{
+						Dir: "/path/to/clones",
+					},
+					DriverConfig: config.GitHub{
+						Domain: "github.com",
+					},
+				},
+				source.Source{
+					Name:        "test-source",
+					Description: "github.com",
+					Driver: &github.Driver{
+						Config: config.GitHub{
+							Domain: "github.com",
+						},
+						Logger: logging.Prefix(&logger, "source[test-source]: "),
+					},
+				},
+			),
+		)
+	})
+})

--- a/cmd/gritd/internal/source/sourcebuilder/doc.go
+++ b/cmd/gritd/internal/source/sourcebuilder/doc.go
@@ -1,0 +1,4 @@
+// Package sourcebuilder constructs the source.Source and source.Driver values
+// used by the daemon from the config.Source definitions in the Grit
+// configuration.
+package sourcebuilder

--- a/cmd/gritd/internal/source/sourcebuilder/ginkgo_test.go
+++ b/cmd/gritd/internal/source/sourcebuilder/ginkgo_test.go
@@ -1,0 +1,15 @@
+package sourcebuilder_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}


### PR DESCRIPTION
This PR adds the `sourcebuilder` package which is responsible for constructing `source.Source` values (as used by the daemon at runtime) from their `config.Source` counterparts (as loaded from the configuration).