### PR TITLE
Move responsibility for setting up logging targets outside Source implementations.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/dogmatiq/dodeca v1.3.0
+	github.com/dogmatiq/dodeca v1.3.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/manifoldco/promptui v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dogmatiq/dodeca v1.3.0 h1:iej0oGuogRzctXfXaWQGujorqf9Jq/Zuc83ftMu2dIk=
-github.com/dogmatiq/dodeca v1.3.0/go.mod h1:3yoxWYqSso+ijE4DxzW6QJRkQa69dnIAXVM37JUqeRk=
+github.com/dogmatiq/dodeca v1.3.1 h1:Kd7hr4Pr1Ej442jLI6vvt8A0AP2JynkkHY4yhT4cNCY=
+github.com/dogmatiq/dodeca v1.3.1/go.mod h1:3yoxWYqSso+ijE4DxzW6QJRkQa69dnIAXVM37JUqeRk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=

--- a/internal/daemon/internal/deps/source.go
+++ b/internal/daemon/internal/deps/source.go
@@ -10,12 +10,8 @@ import (
 func init() {
 	Container.Provide(func(
 		cfg config.Config,
-		logger logging.Logger,
 	) source.List {
-		builder := &sourcebuilder.Builder{
-			Logger: logger,
-		}
-
+		builder := &sourcebuilder.Builder{}
 		return builder.FromConfig(cfg)
 	})
 

--- a/internal/daemon/internal/source/cloner_test.go
+++ b/internal/daemon/internal/source/cloner_test.go
@@ -54,7 +54,11 @@ var _ = Describe("type Cloner", func() {
 				logging.Logger,
 			) (BoundCloner, string, error) {
 				return &BoundClonerStub{
-					CloneFunc: func(c context.Context, s string) error {
+					CloneFunc: func(
+						context.Context,
+						string,
+						logging.Logger,
+					) error {
 						return nil
 					},
 				}, "clone-dir", nil
@@ -155,7 +159,11 @@ var _ = Describe("type Cloner", func() {
 				logging.Logger,
 			) (BoundCloner, string, error) {
 				return &BoundClonerStub{
-					CloneFunc: func(c context.Context, s string) error {
+					CloneFunc: func(
+						context.Context,
+						string,
+						logging.Logger,
+					) error {
 						return errors.New("<error>")
 					},
 				}, "clone-dir", nil

--- a/internal/daemon/internal/source/driver.go
+++ b/internal/daemon/internal/source/driver.go
@@ -13,7 +13,7 @@ type Driver interface {
 	//
 	// It is called before the daemon starts serving API requests. If an error
 	// is returned, the daemon fails to start.
-	Init(ctx context.Context) error
+	Init(ctx context.Context, logger logging.Logger) error
 
 	// Run performs any ongoing behavior required by the driver.
 	//
@@ -22,7 +22,7 @@ type Driver interface {
 	// context is canceled when the daemon shuts down.
 	//
 	// If it returns an error before ctx is canceled, the daemon is stopped.
-	Run(ctx context.Context) error
+	Run(ctx context.Context, logger logging.Logger) error
 
 	// Status returns a brief description of the status of the driver.
 	//
@@ -42,13 +42,10 @@ type Driver interface {
 	// The query string is typically captured directly from user input and has
 	// not been sanitized. The implementation must not return an error if the
 	// query is invalid; instead return an empty slice.
-	//
-	// clientLog is a target for any log output that should be sent to the
-	// client and displayed to the user.
 	Resolve(
 		ctx context.Context,
 		query string,
-		clientLog logging.Logger,
+		logger logging.Logger,
 	) ([]Repo, error)
 
 	// NewBoundCloner returns a bound cloner that clones the repository with the
@@ -56,15 +53,12 @@ type Driver interface {
 	//
 	// id is the repository ID, as discovered by a prior call to Resolve().
 	//
-	// clientLog is a target for any log output that should be sent to the
-	// client and displayed to the user while cloning.
-	//
 	// dir is the sub-directory that the clone should be placed into, relative
 	// to the source's configured clone directory. Typically this should be some
 	// form of the repository's name, sanitized for use as a directory name.
 	NewBoundCloner(
 		ctx context.Context,
 		id string,
-		clientLog logging.Logger,
+		logger logging.Logger,
 	) (c BoundCloner, dir string, err error)
 }

--- a/internal/daemon/internal/source/internal/fixtures/cloner.go
+++ b/internal/daemon/internal/source/internal/fixtures/cloner.go
@@ -3,18 +3,24 @@ package fixtures
 import (
 	"context"
 	"errors"
+
+	"github.com/dogmatiq/dodeca/logging"
 )
 
 // BoundClonerStub is a test implementation of the source.BoundCloner interface.
 type BoundClonerStub struct {
-	CloneFunc func(context.Context, string) error
+	CloneFunc func(context.Context, string, logging.Logger) error
 }
 
-// Clone calls s.CloneFunc(ctx, dir) if s.CloneFunc is non-nil; otherwise it
-// returns an error.
-func (s *BoundClonerStub) Clone(ctx context.Context, dir string) error {
+// Clone calls s.CloneFunc(ctx, dir, logger) if s.CloneFunc is non-nil;
+// otherwise it returns an error.
+func (s *BoundClonerStub) Clone(
+	ctx context.Context,
+	dir string,
+	logger logging.Logger,
+) error {
 	if s.CloneFunc != nil {
-		return s.CloneFunc(ctx, dir)
+		return s.CloneFunc(ctx, dir, logger)
 	}
 
 	return errors.New("<not implemented>")

--- a/internal/daemon/internal/source/internal/fixtures/driver.go
+++ b/internal/daemon/internal/source/internal/fixtures/driver.go
@@ -10,27 +10,28 @@ import (
 
 // DriverStub is a test implementation of the source.Driver interface.
 type DriverStub struct {
-	InitFunc           func(context.Context) error
-	RunFunc            func(context.Context) error
+	InitFunc           func(context.Context, logging.Logger) error
+	RunFunc            func(context.Context, logging.Logger) error
 	StatusFunc         func(context.Context) (string, error)
 	ResolveFunc        func(context.Context, string, logging.Logger) ([]source.Repo, error)
 	NewBoundClonerFunc func(context.Context, string, logging.Logger) (source.BoundCloner, string, error)
 }
 
-// Init calls s.InitFunc(ctx) if s.InitFunc is non-nil; otherwise it returns
-// nil.
-func (s *DriverStub) Init(ctx context.Context) error {
+// Init calls s.InitFunc(ctx, logger) if s.InitFunc is non-nil; otherwise it
+// returns nil.
+func (s *DriverStub) Init(ctx context.Context, logger logging.Logger) error {
 	if s.InitFunc != nil {
-		return s.InitFunc(ctx)
+		return s.InitFunc(ctx, logger)
 	}
 
 	return nil
 }
 
-// Run calls s.RunFunc(ctx) if s.RunFunc is non-nil; otherwise it returns nil.
-func (s *DriverStub) Run(ctx context.Context) error {
+// Run calls s.RunFunc(ctx, logger) if s.RunFunc is non-nil; otherwise it
+// returns nil.
+func (s *DriverStub) Run(ctx context.Context, logger logging.Logger) error {
 	if s.RunFunc != nil {
-		return s.RunFunc(ctx)
+		return s.RunFunc(ctx, logger)
 	}
 
 	return nil
@@ -46,29 +47,29 @@ func (s *DriverStub) Status(ctx context.Context) (string, error) {
 	return "<status>", nil
 }
 
-// Resolve calls s.ResolveFunc(ctx, query, clientLog) if s.ResolveFunc is
-// non-nil; otherwise it returns (nil, nil).
+// Resolve calls s.ResolveFunc(ctx, query, logger) if s.ResolveFunc is non-nil;
+// otherwise it returns (nil, nil).
 func (s *DriverStub) Resolve(
 	ctx context.Context,
 	query string,
-	clientLog logging.Logger,
+	logger logging.Logger,
 ) ([]source.Repo, error) {
 	if s.ResolveFunc != nil {
-		return s.ResolveFunc(ctx, query, clientLog)
+		return s.ResolveFunc(ctx, query, logger)
 	}
 
 	return nil, nil
 }
 
-// NewBoundCloner calls s.NewBoundClonerFunc(ctx, id, clientLog) if
+// NewBoundCloner calls s.NewBoundClonerFunc(ctx, id, logger) if
 // s.NewBoundClonerFunc is non-nil; otherwise it returns an error.
 func (s *DriverStub) NewBoundCloner(
 	ctx context.Context,
 	id string,
-	clientLog logging.Logger,
+	logger logging.Logger,
 ) (c source.BoundCloner, dir string, err error) {
 	if s.NewBoundClonerFunc != nil {
-		return s.NewBoundClonerFunc(ctx, id, clientLog)
+		return s.NewBoundClonerFunc(ctx, id, logger)
 	}
 
 	return nil, "", errors.New("<not implemented>")

--- a/internal/daemon/internal/source/internal/github/cloner_test.go
+++ b/internal/daemon/internal/source/internal/github/cloner_test.go
@@ -17,7 +17,6 @@ var _ = Describe("func Driver.NewBoundCloner()", func() {
 		cancel    context.CancelFunc
 		configure func(*config.GitHub)
 		driver    *Driver
-		logger    logging.DiscardLogger
 	)
 
 	BeforeEach(func() {
@@ -34,22 +33,13 @@ var _ = Describe("func Driver.NewBoundCloner()", func() {
 		})
 
 		It("returns a git.BoundCloner", func() {
-			cloner, dir, err := driver.NewBoundCloner(ctx, gritPublicTestRepo.ID, logger)
+			cloner, dir, err := driver.NewBoundCloner(ctx, gritPublicTestRepo.ID, logging.SilentLogger)
 			skipIfRateLimited(err)
 
 			Expect(cloner).To(Equal(&git.BoundCloner{
 				Config:       driver.Config.Git,
 				SSHEndpoint:  "git@github.com:gritcli/test-public.git",
 				HTTPEndpoint: "https://github.com/gritcli/test-public.git",
-				Logger: logging.Tee(
-					logging.Demote(
-						logging.Prefix(
-							driver.Logger,
-							"clone[446260684]: ",
-						),
-					),
-					logger,
-				),
 			}))
 
 			Expect(dir).To(Equal("gritcli/test-public"))
@@ -65,7 +55,7 @@ var _ = Describe("func Driver.NewBoundCloner()", func() {
 			// TODO: https://github.com/gritcli/grit/issues/13
 			//
 			// Test with a private repository instead.
-			cloner, dir, err := driver.NewBoundCloner(ctx, gritPublicTestRepo.ID, logger)
+			cloner, dir, err := driver.NewBoundCloner(ctx, gritPublicTestRepo.ID, logging.SilentLogger)
 			skipIfRateLimited(err)
 
 			Expect(cloner).To(Equal(&git.BoundCloner{
@@ -73,15 +63,6 @@ var _ = Describe("func Driver.NewBoundCloner()", func() {
 				SSHEndpoint:  "git@github.com:gritcli/test-public.git",
 				HTTPEndpoint: "https://github.com/gritcli/test-public.git",
 				HTTPPassword: driver.Config.Token,
-				Logger: logging.Tee(
-					logging.Demote(
-						logging.Prefix(
-							driver.Logger,
-							"clone[446260684]: ",
-						),
-					),
-					logger,
-				),
 			}))
 
 			Expect(dir).To(Equal("gritcli/test-public"))

--- a/internal/daemon/internal/source/internal/github/driver_test.go
+++ b/internal/daemon/internal/source/internal/github/driver_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("type driver", func() {
+var _ = Describe("type Driver", func() {
 	var (
 		ctx       context.Context
 		cancel    context.CancelFunc
@@ -134,12 +134,11 @@ func initDriver(cfg func() config.GitHub, configure []func(*config.GitHub)) (con
 
 	d := &Driver{
 		Config: c,
-		Logger: logging.SilentLogger,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	if err := d.Init(ctx); err != nil {
+	if err := d.Init(ctx, logging.SilentLogger); err != nil {
 		cancel()
 		skipIfRateLimited(err)
 	}
@@ -150,7 +149,7 @@ func initDriver(cfg func() config.GitHub, configure []func(*config.GitHub)) (con
 		defer GinkgoRecover()
 		defer close(done)
 
-		err := d.Run(ctx)
+		err := d.Run(ctx, logging.SilentLogger)
 		if err != context.Canceled {
 			Expect(err).ShouldNot(HaveOccurred())
 		}

--- a/internal/daemon/internal/source/internal/github/resolve.go
+++ b/internal/daemon/internal/source/internal/github/resolve.go
@@ -13,14 +13,10 @@ import (
 func (d *Driver) Resolve(
 	ctx context.Context,
 	query string,
-	clientLog logging.Logger,
+	logger logging.Logger,
 ) ([]source.Repo, error) {
-	serverLog := logging.Prefix(d.Logger, "resolve[%s]: ", query)
-	clientLog = logging.Tee(serverLog, clientLog) // log everything sent to the client on the server as well
-
 	ownerName, repoName, err := parseRepoName(query)
 	if err != nil {
-		logging.Debug(clientLog, err.Error())
 		return nil, nil
 	}
 
@@ -34,18 +30,32 @@ func (d *Driver) Resolve(
 			}
 		}
 
-		logging.Debug(
-			clientLog,
-			"found %d repo(s) named '%s' by scanning the user's repo cache",
+		logging.Log(
+			logger,
+			"found %d match(es) for '%s' in the repository list for @%s",
 			len(repos),
-			repoName,
+			query,
+			d.cache.CurrentUser().GetLogin(),
 		)
+
+		if len(repos) == 0 {
+			logging.Log(
+				logger,
+				"skipping GitHub API query for '%s' because it is not a fully-qualified repository name",
+				query,
+			)
+		}
 
 		return repos, nil
 	}
 
 	if r, ok := reposByOwner[ownerName][repoName]; ok {
-		logging.Debug(clientLog, "found an exact match in the user's repo cache")
+		logging.Log(
+			logger,
+			"found an exact match for '%s' in the repository list for @%s",
+			query,
+			d.cache.CurrentUser().GetLogin(),
+		)
 
 		return []source.Repo{
 			convertRepo(r),
@@ -55,15 +65,23 @@ func (d *Driver) Resolve(
 	r, res, err := d.client.Repositories.Get(ctx, ownerName, repoName)
 	if err != nil {
 		if res.StatusCode == http.StatusNotFound {
-			logging.Debug(clientLog, "no matches found when querying the API")
+			logging.Log(
+				logger,
+				"no repository named '%s' found by querying the GitHub API",
+				query,
+			)
+
 			return nil, nil
 		}
 
-		logging.Log(serverLog, "unable to query API: %s", err)
 		return nil, err
 	}
 
-	logging.Debug(serverLog, "found an exact match by querying the API")
+	logging.Log(
+		logger,
+		"found a repository named '%s' by querying the GitHub API",
+		query,
+	)
 
 	return []source.Repo{
 		convertRepo(r),

--- a/internal/daemon/internal/source/internal/github/resolve.go
+++ b/internal/daemon/internal/source/internal/github/resolve.go
@@ -30,7 +30,7 @@ func (d *Driver) Resolve(
 			}
 		}
 
-		logging.Log(
+		logging.Debug(
 			logger,
 			"found %d match(es) for '%s' in the repository list for @%s",
 			len(repos),
@@ -39,7 +39,7 @@ func (d *Driver) Resolve(
 		)
 
 		if len(repos) == 0 {
-			logging.Log(
+			logging.Debug(
 				logger,
 				"skipping GitHub API query for '%s' because it is not a fully-qualified repository name",
 				query,
@@ -50,7 +50,7 @@ func (d *Driver) Resolve(
 	}
 
 	if r, ok := reposByOwner[ownerName][repoName]; ok {
-		logging.Log(
+		logging.Debug(
 			logger,
 			"found an exact match for '%s' in the repository list for @%s",
 			query,
@@ -65,7 +65,7 @@ func (d *Driver) Resolve(
 	r, res, err := d.client.Repositories.Get(ctx, ownerName, repoName)
 	if err != nil {
 		if res.StatusCode == http.StatusNotFound {
-			logging.Log(
+			logging.Debug(
 				logger,
 				"no repository named '%s' found by querying the GitHub API",
 				query,
@@ -77,7 +77,7 @@ func (d *Driver) Resolve(
 		return nil, err
 	}
 
-	logging.Log(
+	logging.Debug(
 		logger,
 		"found a repository named '%s' by querying the GitHub API",
 		query,

--- a/internal/daemon/internal/source/sourcebuilder/builder.go
+++ b/internal/daemon/internal/source/sourcebuilder/builder.go
@@ -3,7 +3,6 @@ package sourcebuilder
 import (
 	"sort"
 
-	"github.com/dogmatiq/dodeca/logging"
 	"github.com/gritcli/grit/internal/common/config"
 	"github.com/gritcli/grit/internal/daemon/internal/source"
 	"github.com/gritcli/grit/internal/daemon/internal/source/internal/github"
@@ -11,8 +10,6 @@ import (
 
 // Builder builds source.Source values from Grit configuration.
 type Builder struct {
-	// Logger is the target for log messages from source drivers.
-	Logger logging.Logger
 }
 
 // FromConfig returns the list of enabled sources defined in cfg.
@@ -38,15 +35,9 @@ func (b *Builder) FromConfig(cfg config.Config) source.List {
 
 // FromSourceConfig returns the Source defined in cfg.
 func (b *Builder) FromSourceConfig(cfg config.Source) source.Source {
-	f := &driverFactory{
-		Logger: logging.Prefix(
-			b.Logger,
-			"source[%s]: ",
-			cfg.Name,
-		),
-	}
+	var f driverFactory
 
-	cfg.AcceptVisitor(f)
+	cfg.AcceptVisitor(&f)
 
 	return source.Source{
 		Name:        cfg.Name,
@@ -60,12 +51,10 @@ func (b *Builder) FromSourceConfig(cfg config.Source) source.Source {
 // drivers based on source configurations.
 type driverFactory struct {
 	Driver source.Driver
-	Logger logging.Logger
 }
 
 func (f *driverFactory) VisitGitHubSource(s config.Source, cfg config.GitHub) {
 	f.Driver = &github.Driver{
 		Config: cfg,
-		Logger: f.Logger,
 	}
 }

--- a/internal/daemon/internal/source/sourcebuilder/builder_test.go
+++ b/internal/daemon/internal/source/sourcebuilder/builder_test.go
@@ -1,7 +1,6 @@
 package sourcebuilder_test
 
 import (
-	"github.com/dogmatiq/dodeca/logging"
 	"github.com/gritcli/grit/internal/common/config"
 	"github.com/gritcli/grit/internal/daemon/internal/source"
 	"github.com/gritcli/grit/internal/daemon/internal/source/internal/github"
@@ -13,17 +12,10 @@ import (
 )
 
 var _ = Describe("type Builder", func() {
-	var (
-		logger  logging.BufferedLogger
-		builder *Builder
-	)
+	var builder *Builder
 
 	BeforeEach(func() {
-		logger.Reset()
-
-		builder = &Builder{
-			Logger: &logger,
-		}
+		builder = &Builder{}
 	})
 
 	Describe("func FromConfig()", func() {
@@ -59,7 +51,6 @@ var _ = Describe("type Builder", func() {
 						Config: config.GitHub{
 							Domain: "github.com",
 						},
-						Logger: logging.Prefix(&logger, "source[github-test-source]: "),
 					},
 				},
 			))
@@ -119,7 +110,6 @@ var _ = Describe("type Builder", func() {
 						Config: config.GitHub{
 							Domain: "github.com",
 						},
-						Logger: logging.Prefix(&logger, "source[test-source]: "),
 					},
 				},
 			),

--- a/internal/daemon/run.go
+++ b/internal/daemon/run.go
@@ -57,7 +57,14 @@ func initSourceDrivers(ctx context.Context, logger logging.Logger, sources sourc
 	for _, src := range sources {
 		src := src // capture loop variable
 		g.Go(func() error {
-			return src.Driver.Init(ctx)
+			return src.Driver.Init(
+				ctx,
+				logging.Prefix(
+					logger,
+					"source[%s]: ",
+					src.Name,
+				),
+			)
 		})
 	}
 
@@ -71,7 +78,14 @@ func runSourceDrivers(ctx context.Context, logger logging.Logger, sources source
 	for _, src := range sources {
 		src := src // capture loop variable
 		g.Go(func() error {
-			return src.Driver.Run(ctx)
+			return src.Driver.Run(
+				ctx,
+				logging.Prefix(
+					logger,
+					"source[%s]: ",
+					src.Name,
+				),
+			)
 		})
 	}
 


### PR DESCRIPTION
This forces the source implementations into consistent client/server logging behaviour.

Fixes #23 