### PR TITLE
Refactor driver config system so that drivers don't _have_ to use gohcl.

### DIFF
--- a/builtins/githubsource/config.go
+++ b/builtins/githubsource/config.go
@@ -3,6 +3,8 @@ package githubsource
 import (
 	"github.com/gritcli/grit/builtins/gitvcs"
 	"github.com/gritcli/grit/driver/sourcedriver"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
 )
 
 // Config contains configuration specific to the GitHub driver.
@@ -42,16 +44,12 @@ type configSchema struct {
 	Token  string `hcl:"token,optional"`
 }
 
-func (s *configSchema) Normalize(
-	ctx sourcedriver.ConfigContext,
-) (sourcedriver.Config, error) {
-	if s.Domain == "" {
-		s.Domain = "github.com"
-	}
+// configLoader is an implementation of vcsdriver.ConfigLoader for Git.
+type configLoader struct{}
 
+func (configLoader) Defaults(ctx sourcedriver.ConfigContext) (sourcedriver.Config, error) {
 	cfg := Config{
-		Domain: s.Domain,
-		Token:  s.Token,
+		Domain: "github.com",
 	}
 
 	if err := ctx.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
@@ -59,4 +57,41 @@ func (s *configSchema) Normalize(
 	}
 
 	return cfg, nil
+}
+
+func (configLoader) Merge(ctx sourcedriver.ConfigContext, c sourcedriver.Config, b hcl.Body) (sourcedriver.Config, error) {
+	var s configSchema
+	if diag := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diag.HasErrors() {
+		return nil, diag
+	}
+
+	cfg := c.(Config) // clone
+
+	if s.Domain != "" {
+		cfg.Domain = s.Domain
+	}
+
+	if s.Token != "" {
+		cfg.Token = s.Token
+	}
+
+	if err := ctx.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func (l configLoader) ImplicitSources(ctx sourcedriver.ConfigContext) ([]sourcedriver.ImplicitSource, error) {
+	cfg, err := l.Defaults(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return []sourcedriver.ImplicitSource{
+		{
+			Name:   "github",
+			Config: cfg,
+		},
+	}, nil
 }

--- a/builtins/githubsource/config.go
+++ b/builtins/githubsource/config.go
@@ -47,25 +47,18 @@ type configSchema struct {
 // configLoader is an implementation of vcsdriver.ConfigLoader for Git.
 type configLoader struct{}
 
-func (configLoader) Defaults(ctx sourcedriver.ConfigContext) (sourcedriver.Config, error) {
-	cfg := Config{
-		Domain: "github.com",
-	}
-
-	if err := ctx.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
-}
-
-func (configLoader) Merge(ctx sourcedriver.ConfigContext, c sourcedriver.Config, b hcl.Body) (sourcedriver.Config, error) {
+func (configLoader) Unmarshal(
+	ctx sourcedriver.ConfigContext,
+	b hcl.Body,
+) (sourcedriver.Config, error) {
 	var s configSchema
 	if diag := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diag.HasErrors() {
 		return nil, diag
 	}
 
-	cfg := c.(Config) // clone
+	cfg := Config{
+		Domain: "github.com",
+	}
 
 	if s.Domain != "" {
 		cfg.Domain = s.Domain
@@ -83,8 +76,11 @@ func (configLoader) Merge(ctx sourcedriver.ConfigContext, c sourcedriver.Config,
 }
 
 func (l configLoader) ImplicitSources(ctx sourcedriver.ConfigContext) ([]sourcedriver.ImplicitSource, error) {
-	cfg, err := l.Defaults(ctx)
-	if err != nil {
+	cfg := Config{
+		Domain: "github.com",
+	}
+
+	if err := ctx.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
 		return nil, err
 	}
 

--- a/builtins/githubsource/config.go
+++ b/builtins/githubsource/config.go
@@ -43,7 +43,7 @@ type configSchema struct {
 }
 
 func (s *configSchema) Normalize(
-	nc sourcedriver.ConfigNormalizeContext,
+	ctx sourcedriver.ConfigContext,
 ) (sourcedriver.Config, error) {
 	if s.Domain == "" {
 		s.Domain = "github.com"
@@ -54,7 +54,7 @@ func (s *configSchema) Normalize(
 		Token:  s.Token,
 	}
 
-	if err := nc.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
+	if err := ctx.UnmarshalVCSConfig(gitvcs.Registration.Name, &cfg.Git); err != nil {
 		return nil, err
 	}
 

--- a/builtins/githubsource/config_test.go
+++ b/builtins/githubsource/config_test.go
@@ -31,7 +31,7 @@ var _ = Describe("type Config", func() {
 	})
 })
 
-var _ = Describe("type configSchema", func() {
+var _ = Describe("type configLoader", func() {
 	configtest.TestSourceDriver(
 		Registration,
 		Config{},

--- a/builtins/githubsource/registration.go
+++ b/builtins/githubsource/registration.go
@@ -7,14 +7,7 @@ import (
 // Registration contains information about the driver used to register it with
 // Grit's driver registry.
 var Registration = sourcedriver.Registration{
-	Name:        "github",
-	Description: "adds support for GitHub and GitHub Enterprise Server as repository sources",
-	NewConfigSchema: func() sourcedriver.ConfigSchema {
-		return &configSchema{}
-	},
-	ImplicitSources: map[string]sourcedriver.ConfigSchema{
-		"github": &configSchema{
-			Domain: "github.com",
-		},
-	},
+	Name:         "github",
+	Description:  "adds support for GitHub and GitHub Enterprise Server as repository sources",
+	ConfigLoader: configLoader{},
 }

--- a/builtins/gitvcs/config.go
+++ b/builtins/gitvcs/config.go
@@ -53,16 +53,16 @@ type configSchema struct {
 	PreferHTTP *bool `hcl:"prefer_http"`
 }
 
-// configNormalizer is an implementation of vcsdriver.ConfigNormalizer for Git.
-type configNormalizer struct{}
+// configLoader is an implementation of vcsdriver.ConfigLoader for Git.
+type configLoader struct{}
 
-func (configNormalizer) Defaults(nc vcsdriver.ConfigNormalizeContext) (vcsdriver.Config, error) {
+func (configLoader) Defaults(ctx vcsdriver.ConfigContext) (vcsdriver.Config, error) {
 	return Config{}, nil
 }
 
-func (configNormalizer) Merge(nc vcsdriver.ConfigNormalizeContext, c vcsdriver.Config, b hcl.Body) (vcsdriver.Config, error) {
+func (configLoader) Merge(ctx vcsdriver.ConfigContext, c vcsdriver.Config, b hcl.Body) (vcsdriver.Config, error) {
 	var s configSchema
-	if diag := gohcl.DecodeBody(b, nc.EvalContext(), &s); diag.HasErrors() {
+	if diag := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diag.HasErrors() {
 		return nil, diag
 	}
 
@@ -72,7 +72,7 @@ func (configNormalizer) Merge(nc vcsdriver.ConfigNormalizeContext, c vcsdriver.C
 		cfg.SSHKeyFile = s.SSHKey.File
 		cfg.SSHKeyPassphrase = s.SSHKey.Passphrase
 
-		if err := nc.NormalizePath(&cfg.SSHKeyFile); err != nil {
+		if err := ctx.NormalizePath(&cfg.SSHKeyFile); err != nil {
 			return Config{}, err
 		}
 	}

--- a/builtins/gitvcs/config.go
+++ b/builtins/gitvcs/config.go
@@ -60,7 +60,11 @@ func (configLoader) Defaults(ctx vcsdriver.ConfigContext) (vcsdriver.Config, err
 	return Config{}, nil
 }
 
-func (configLoader) Merge(ctx vcsdriver.ConfigContext, c vcsdriver.Config, b hcl.Body) (vcsdriver.Config, error) {
+func (configLoader) UnmarshalAndMerge(
+	ctx vcsdriver.ConfigContext,
+	c vcsdriver.Config,
+	b hcl.Body,
+) (vcsdriver.Config, error) {
 	var s configSchema
 	if diag := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diag.HasErrors() {
 		return nil, diag

--- a/builtins/gitvcs/config_test.go
+++ b/builtins/gitvcs/config_test.go
@@ -38,7 +38,7 @@ var _ = Describe("type Config", func() {
 	})
 })
 
-var _ = Describe("type configSchema", func() {
+var _ = Describe("type configLoader", func() {
 	configtest.TestVCSDriver(
 		Registration,
 		Config{},

--- a/builtins/gitvcs/registration.go
+++ b/builtins/gitvcs/registration.go
@@ -5,7 +5,7 @@ import "github.com/gritcli/grit/driver/vcsdriver"
 // Registration contains information about the driver used to register it with
 // Grit's driver registry.
 var Registration = vcsdriver.Registration{
-	Name:             "git",
-	Description:      "adds support for Git repositories",
-	ConfigNormalizer: configNormalizer{},
+	Name:         "git",
+	Description:  "adds support for Git repositories",
+	ConfigLoader: configLoader{},
 }

--- a/config/load.go
+++ b/config/load.go
@@ -216,10 +216,12 @@ func (l *loader) finalize() (Config, error) {
 		return Config{}, err
 	}
 
-	l.populateImplicitSources()
-
 	cfg := Config{
 		Daemon: l.daemon,
+	}
+
+	if err := l.populateImplicitSources(&cfg); err != nil {
+		return Config{}, err
 	}
 
 	for _, i := range l.sources {

--- a/config/load.go
+++ b/config/load.go
@@ -91,6 +91,10 @@ type loader struct {
 	// global configuration for that driver.
 	globalVCSFiles map[string]string
 
+	// defaultVCSs is a map of VCS driver name to the default configuration for
+	// that driver.
+	defaultVCSs map[string]vcsdriver.Config
+
 	// globalVCSs is a map of VCS driver name to the global configuration for
 	// that driver.
 	globalVCSs map[string]vcsdriver.Config
@@ -108,11 +112,24 @@ type loader struct {
 // Files that begin with and underscore (_) or dot (.) are ignored. It does not
 // descend into sub-directories.
 func (l *loader) Load() (Config, error) {
+	if err := l.prepare(); err != nil {
+		return Config{}, err
+	}
+
 	if err := l.load(); err != nil {
 		return Config{}, err
 	}
 
 	return l.finalize()
+}
+
+// prepare prepares the loader to load configuration.
+func (l *loader) prepare() error {
+	if err := l.populateDefaultVCSs(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (l *loader) load() error {
@@ -209,10 +226,6 @@ func (l *loader) finalize() (Config, error) {
 	}
 
 	if err := l.populateGlobalClonesDefaults(); err != nil {
-		return Config{}, err
-	}
-
-	if err := l.populateImplicitGlobalVCSs(); err != nil {
 		return Config{}, err
 	}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -196,18 +196,18 @@ func newRegistry() *registry.Registry {
 	return reg
 }
 
-func newSourceLoader() *stubs.SourceDriverConfigLoader {
-	return &stubs.SourceDriverConfigLoader{
+func newSourceLoader() *stubs.SourceConfigLoader {
+	return &stubs.SourceConfigLoader{
 		UnmarshalFunc: func(
 			ctx sourcedriver.ConfigContext,
 			b hcl.Body,
 		) (sourcedriver.Config, error) {
-			var s stubs.SourceDriverConfigSchema
+			var s stubs.SourceConfigSchema
 			if diags := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diags.HasErrors() {
 				return nil, diags
 			}
 
-			cfg := &stubs.SourceDriverConfig{
+			cfg := &stubs.SourceConfig{
 				ArbitraryAttribute: "<default>",
 			}
 
@@ -223,7 +223,7 @@ func newSourceLoader() *stubs.SourceDriverConfigLoader {
 				return nil, err
 			}
 
-			vcsConfig := &stubs.VCSDriverConfig{}
+			vcsConfig := &stubs.VCSConfig{}
 			if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &vcsConfig); err != nil {
 				return nil, err
 			}
@@ -237,12 +237,12 @@ func newSourceLoader() *stubs.SourceDriverConfigLoader {
 	}
 }
 
-func newVCSLoader() *stubs.VCSDriverConfigLoader {
-	return &stubs.VCSDriverConfigLoader{
+func newVCSLoader() *stubs.VCSConfigLoader {
+	return &stubs.VCSConfigLoader{
 		DefaultsFunc: func(
 			vcsdriver.ConfigContext,
 		) (vcsdriver.Config, error) {
-			return &stubs.VCSDriverConfig{
+			return &stubs.VCSConfig{
 				ArbitraryAttribute: "<default>",
 			}, nil
 		},
@@ -251,12 +251,12 @@ func newVCSLoader() *stubs.VCSDriverConfigLoader {
 			c vcsdriver.Config,
 			b hcl.Body,
 		) (vcsdriver.Config, error) {
-			var s stubs.VCSDriverConfigSchema
+			var s stubs.VCSConfigSchema
 			if diags := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diags.HasErrors() {
 				return nil, diags
 			}
 
-			cfg := *c.(*stubs.VCSDriverConfig) // clone
+			cfg := *c.(*stubs.VCSConfig) // clone
 
 			if s.ArbitraryAttribute != "" {
 				// Note, we concat to the existing config here (not replace) so

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -190,8 +190,8 @@ func newRegistry() *registry.Registry {
 	reg.RegisterVCSDriver(
 		testVCSDriverName,
 		vcsdriver.Registration{
-			Name:             testVCSDriverName,
-			ConfigNormalizer: newVCSNormalizer(),
+			Name:         testVCSDriverName,
+			ConfigLoader: newVCSLoader(),
 		},
 	)
 
@@ -233,17 +233,17 @@ func newSourceStub() *stubs.SourceDriverConfigSchema {
 	}
 }
 
-func newVCSNormalizer() *stubs.VCSDriverConfigNormalizer {
-	return &stubs.VCSDriverConfigNormalizer{
+func newVCSLoader() *stubs.VCSDriverConfigLoader {
+	return &stubs.VCSDriverConfigLoader{
 		DefaultsFunc: func(
-			nc vcsdriver.ConfigNormalizeContext,
+			vcsdriver.ConfigContext,
 		) (vcsdriver.Config, error) {
 			return &stubs.VCSDriverConfig{
 				ArbitraryAttribute: "<default>",
 			}, nil
 		},
 		MergeFunc: func(
-			nc vcsdriver.ConfigNormalizeContext,
+			ctx vcsdriver.ConfigContext,
 			c vcsdriver.Config,
 			b hcl.Body,
 		) (vcsdriver.Config, error) {
@@ -251,7 +251,7 @@ func newVCSNormalizer() *stubs.VCSDriverConfigNormalizer {
 
 			var s stubs.VCSDriverConfigSchema
 
-			if diags := gohcl.DecodeBody(b, nc.EvalContext(), &s); diags.HasErrors() {
+			if diags := gohcl.DecodeBody(b, ctx.EvalContext(), &s); diags.HasErrors() {
 				return nil, diags
 			}
 
@@ -266,7 +266,7 @@ func newVCSNormalizer() *stubs.VCSDriverConfigNormalizer {
 				cfg.FilesystemPath = s.FilesystemPath
 			}
 
-			if err := nc.NormalizePath(&cfg.FilesystemPath); err != nil {
+			if err := ctx.NormalizePath(&cfg.FilesystemPath); err != nil {
 				return nil, err
 			}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -203,7 +203,7 @@ func newRegistry() *registry.Registry {
 func newSourceStub() *stubs.SourceDriverConfigSchema {
 	return &stubs.SourceDriverConfigSchema{
 		NormalizeFunc: func(
-			nc sourcedriver.ConfigNormalizeContext,
+			ctx sourcedriver.ConfigContext,
 			s *stubs.SourceDriverConfigSchema,
 		) (sourcedriver.Config, error) {
 			cfg := &stubs.SourceDriverConfig{
@@ -215,12 +215,12 @@ func newSourceStub() *stubs.SourceDriverConfigSchema {
 				cfg.ArbitraryAttribute = "<default>"
 			}
 
-			if err := nc.NormalizePath(&cfg.FilesystemPath); err != nil {
+			if err := ctx.NormalizePath(&cfg.FilesystemPath); err != nil {
 				return nil, err
 			}
 
 			vcsConfig := &stubs.VCSDriverConfig{}
-			if err := nc.UnmarshalVCSConfig(testVCSDriverName, &vcsConfig); err != nil {
+			if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &vcsConfig); err != nil {
 				return nil, err
 			}
 

--- a/config/load_test.go
+++ b/config/load_test.go
@@ -246,7 +246,7 @@ func newVCSLoader() *stubs.VCSDriverConfigLoader {
 				ArbitraryAttribute: "<default>",
 			}, nil
 		},
-		MergeFunc: func(
+		UnmarshalAndMergeFunc: func(
 			ctx vcsdriver.ConfigContext,
 			c vcsdriver.Config,
 			b hcl.Body,

--- a/config/loadclones.go
+++ b/config/loadclones.go
@@ -47,8 +47,8 @@ func (l *loader) populateGlobalClonesDefaults() error {
 	return nil
 }
 
-// finalizeSouceSpecific returns the clones configuration to use for a specific
-// source.
+// finalizeSourceSpecificClones returns the clones configuration to use for a
+// specific source.
 func (l *loader) finalizeSourceSpecificClones(
 	i intermediateSource,
 	s *clonesSchema,
@@ -73,4 +73,12 @@ func (l *loader) finalizeSourceSpecificClones(
 	}
 
 	return cfg, nil
+}
+
+// finalizeImplicitSourceClones returns the clones configuration to use for an
+// implicit source.
+func (l *loader) finalizeImplicitSourceClones(name string) Clones {
+	return Clones{
+		Dir: filepath.Join(l.globalClones.Dir, name),
+	}
 }

--- a/config/loadclones_test.go
+++ b/config/loadclones_test.go
@@ -27,10 +27,10 @@ var _ = Describe("func Load() (clones configuration)", func() {
 				Clones: Clones{
 					Dir: "/path/to/clones/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -52,10 +52,10 @@ var _ = Describe("func Load() (clones configuration)", func() {
 				Clones: Clones{
 					Dir: "/path/to/clones",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -81,10 +81,10 @@ var _ = Describe("func Load() (clones configuration)", func() {
 				Clones: Clones{
 					Dir: "/path/to/elsewhere",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},

--- a/config/loadsource.go
+++ b/config/loadsource.go
@@ -246,7 +246,10 @@ func (c *sourceContext) UnmarshalVCSConfig(driver string, v interface{}) error {
 
 		cfg, ok := c.sourceVCSs[alias]
 		if !ok {
-			cfg = c.loader.globalVCSs[alias]
+			cfg, ok = c.loader.globalVCSs[alias]
+		}
+		if !ok {
+			cfg = c.loader.defaultVCSs[alias]
 		}
 
 		rv := reflect.ValueOf(cfg)

--- a/config/loadsource.go
+++ b/config/loadsource.go
@@ -8,10 +8,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gritcli/grit/driver/sourcedriver"
 	"github.com/gritcli/grit/driver/vcsdriver"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/gohcl"
 )
 
 // sourceNameRegexp is a regular expression used to validate source names.
@@ -23,7 +21,6 @@ var sourceNameRegexp = regexp.MustCompile(`(?i)^[a-z_]+$`)
 // configuration files have been loaded.
 type intermediateSource struct {
 	Schema sourceSchema
-	Driver sourcedriver.ConfigSchema
 	VCSs   map[string]hcl.Body
 	File   string
 }
@@ -58,24 +55,8 @@ func (l *loader) mergeSource(file string, s sourceSchema) error {
 		)
 	}
 
-	reg, ok := l.Registry.SourceDriverByAlias(s.Driver)
-	if !ok {
-		return fmt.Errorf(
-			"the '%s' source uses an unrecognized driver ('%s'), the supported source drivers are '%s'",
-			s.Name,
-			s.Driver,
-			strings.Join(l.Registry.SourceDriverAliases(), "', '"),
-		)
-	}
-
-	bodySchema := reg.NewConfigSchema()
-	if diag := gohcl.DecodeBody(s.DriverBody, nil, bodySchema); diag.HasErrors() {
-		return diag
-	}
-
 	i := intermediateSource{
 		Schema: s,
-		Driver: bodySchema,
 		VCSs:   map[string]hcl.Body{},
 		File:   file,
 	}
@@ -100,30 +81,51 @@ func (l *loader) mergeSource(file string, s sourceSchema) error {
 //
 // Any implicit source with a name that has already been defined in the
 // configuration files is ignored.
-func (l *loader) populateImplicitSources() {
-	for alias, reg := range l.Registry.SourceDrivers() {
-		for name, schema := range reg.ImplicitSources {
-			lowerName := strings.ToLower(name)
+func (l *loader) populateImplicitSources(cfg *Config) error {
+	ctx := &sourceContext{
+		loader: l,
+	}
 
-			if l.sources == nil {
-				l.sources = map[string]intermediateSource{}
-			} else if _, ok := l.sources[lowerName]; ok {
+	for alias, reg := range l.Registry.SourceDrivers() {
+		sources, err := reg.ConfigLoader.ImplicitSources(ctx)
+		if err != nil {
+			return fmt.Errorf(
+				"the implicit sources provided by the '%s' driver cannot be loaded: %w",
+				alias,
+				err,
+			)
+		}
+
+		for _, src := range sources {
+			lowerName := strings.ToLower(src.Name)
+			if _, ok := l.sources[lowerName]; ok {
 				continue
 			}
 
-			l.sources[lowerName] = intermediateSource{
-				Schema: sourceSchema{
-					Name:   name,
-					Driver: alias,
-				},
-				Driver: schema,
-			}
+			cfg.Sources = append(cfg.Sources, Source{
+				Name:    src.Name,
+				Enabled: true,
+				Clones:  l.finalizeImplicitSourceClones(src.Name),
+				Driver:  src.Config,
+			})
 		}
 	}
+
+	return nil
 }
 
 // finalizeSource returns a source built from its intermediate representation.
 func (l *loader) finalizeSource(i intermediateSource) (Source, error) {
+	reg, ok := l.Registry.SourceDriverByAlias(i.Schema.Driver)
+	if !ok {
+		return Source{}, fmt.Errorf(
+			"the '%s' source uses an unrecognized driver ('%s'), the supported source drivers are '%s'",
+			i.Schema.Name,
+			i.Schema.Driver,
+			strings.Join(l.Registry.SourceDriverAliases(), "', '"),
+		)
+	}
+
 	clones, err := l.finalizeSourceSpecificClones(i, i.Schema.Clones)
 	if err != nil {
 		return Source{}, err
@@ -136,19 +138,26 @@ func (l *loader) finalizeSource(i intermediateSource) (Source, error) {
 
 	ctx := &sourceContext{
 		loader:     l,
-		globalVCSs: l.globalVCSs,
 		sourceVCSs: sourceVCSs,
 	}
 
-	cfg, err := i.Driver.Normalize(ctx)
+	cfg, err := reg.ConfigLoader.Defaults(ctx)
 	if err != nil {
-		if i.File == "" {
-			return Source{}, fmt.Errorf(
-				"the configuration for the implicit '%s' source (provided by the '%s' driver) cannot be loaded: %w",
-				i.Schema.Name,
-				i.Schema.Driver,
-				err,
-			)
+		if isHCLError(err) {
+			return Source{}, err
+		}
+
+		return Source{}, fmt.Errorf(
+			"the default configuration for the '%s' source driver cannot be loaded: %w",
+			i.Schema.Driver,
+			err,
+		)
+	}
+
+	cfg, err = reg.ConfigLoader.Merge(ctx, cfg, i.Schema.DriverBody)
+	if err != nil {
+		if isHCLError(err) {
+			return Source{}, err
 		}
 
 		return Source{}, fmt.Errorf(
@@ -177,7 +186,6 @@ func (l *loader) finalizeSource(i intermediateSource) (Source, error) {
 // sourceContext is an implementation of sourcedriver.ConfigContext.
 type sourceContext struct {
 	loader     *loader
-	globalVCSs map[string]vcsdriver.Config
 	sourceVCSs map[string]vcsdriver.Config
 }
 
@@ -238,7 +246,7 @@ func (c *sourceContext) UnmarshalVCSConfig(driver string, v interface{}) error {
 
 		cfg, ok := c.sourceVCSs[alias]
 		if !ok {
-			cfg = c.globalVCSs[alias]
+			cfg = c.loader.globalVCSs[alias]
 		}
 
 		rv := reflect.ValueOf(cfg)

--- a/config/loadsource.go
+++ b/config/loadsource.go
@@ -141,20 +141,7 @@ func (l *loader) finalizeSource(i intermediateSource) (Source, error) {
 		sourceVCSs: sourceVCSs,
 	}
 
-	cfg, err := reg.ConfigLoader.Defaults(ctx)
-	if err != nil {
-		if isHCLError(err) {
-			return Source{}, err
-		}
-
-		return Source{}, fmt.Errorf(
-			"the default configuration for the '%s' source driver cannot be loaded: %w",
-			i.Schema.Driver,
-			err,
-		)
-	}
-
-	cfg, err = reg.ConfigLoader.Merge(ctx, cfg, i.Schema.DriverBody)
+	cfg, err := reg.ConfigLoader.Unmarshal(ctx, i.Schema.DriverBody)
 	if err != nil {
 		if isHCLError(err) {
 			return Source{}, err

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"errors"
 	"reflect"
 
 	. "github.com/gritcli/grit/config"
@@ -81,7 +82,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					Dir: "~/grit/test_source",
 				},
 				Driver: &stubs.SourceDriverConfig{
-					ArbitraryAttribute: "<explicit>",
+					ArbitraryAttribute: "<default> + <explicit>",
 					VCSs: map[string]vcsdriver.Config{
 						testVCSDriverName: &stubs.VCSDriverConfig{
 							ArbitraryAttribute: "<default>",
@@ -109,19 +110,31 @@ var _ = Describe("func Load() (source configuration)", func() {
 				},
 			}),
 			func(reg *registry.Registry) {
-				schema := newSourceStub()
-				schema.ArbitraryAttribute = "<implicit>"
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					cfg := &stubs.SourceDriverConfig{
+						ArbitraryAttribute: "<implicit>",
+					}
+
+					if err := unmarshalVCSConfig(ctx, cfg, testVCSDriverName); err != nil {
+						return nil, err
+					}
+
+					return []sourcedriver.ImplicitSource{
+						{
+							Name:   "implicit",
+							Config: cfg,
+						},
+					}, nil
+				}
 
 				reg.RegisterSourceDriver(
 					"test_source_driver_with_implicit_source",
 					sourcedriver.Registration{
-						Name: "test_source_driver",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return newSourceStub()
-						},
-						ImplicitSources: map[string]sourcedriver.ConfigSchema{
-							"implicit": schema,
-						},
+						Name:         "test_source_driver",
+						ConfigLoader: loader,
 					},
 				)
 			},
@@ -140,7 +153,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					Dir: "~/grit/implicit",
 				},
 				Driver: &stubs.SourceDriverConfig{
-					ArbitraryAttribute: "<explicit>",
+					ArbitraryAttribute: "<default> + <explicit>",
 					VCSs: map[string]vcsdriver.Config{
 						testVCSDriverName: &stubs.VCSDriverConfig{
 							ArbitraryAttribute: "<default>",
@@ -149,33 +162,37 @@ var _ = Describe("func Load() (source configuration)", func() {
 				},
 			}),
 			func(reg *registry.Registry) {
-				schema := newSourceStub()
-				schema.ArbitraryAttribute = "<implicit>"
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					return []sourcedriver.ImplicitSource{
+						{
+							Name: "implicit",
+							Config: &stubs.SourceDriverConfig{
+								ArbitraryAttribute: "<implicit>",
+							},
+						},
+					}, nil
+				}
 
 				reg.RegisterSourceDriver(
 					"test_source_driver_with_implicit_source",
 					sourcedriver.Registration{
-						Name: "test_source_driver",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return newSourceStub()
-						},
-						ImplicitSources: map[string]sourcedriver.ConfigSchema{
-							"implicit": schema,
-						},
+						Name:         "test_source_driver",
+						ConfigLoader: loader,
 					},
 				)
 			},
 		),
 		Entry(
 			`disambiguate VCS drivers with the same name`,
-			[]string{
-				`source "test_source" "test_source_driver_uses_ambiguous_vcs" {}`,
-			},
+			[]string{},
 			withSource(defaultConfig, Source{
-				Name:    "test_source",
+				Name:    "implicit",
 				Enabled: true,
 				Clones: Clones{
-					Dir: "~/grit/test_source",
+					Dir: "~/grit/implicit",
 				},
 				Driver: &stubs.SourceDriverConfig{
 					VCSs: map[string]vcsdriver.Config{
@@ -200,28 +217,33 @@ var _ = Describe("func Load() (source configuration)", func() {
 					},
 				)
 
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					var target aDifferentVCSConfigConcreteType
+					if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &target); err != nil {
+						return nil, err
+					}
+
+					return []sourcedriver.ImplicitSource{
+						{
+							Name: "implicit",
+							Config: &stubs.SourceDriverConfig{
+								VCSs: map[string]vcsdriver.Config{
+									testVCSDriverName: target,
+								},
+							},
+						},
+					}, nil
+
+				}
+
 				reg.RegisterSourceDriver(
 					"test_source_driver_uses_ambiguous_vcs",
 					sourcedriver.Registration{
-						Name: "test_source_driver_uses_ambiguous_vcs",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return &stubs.SourceDriverConfigSchema{
-								NormalizeFunc: func(
-									ctx sourcedriver.ConfigContext,
-									s *stubs.SourceDriverConfigSchema,
-								) (sourcedriver.Config, error) {
-									var target aDifferentVCSConfigConcreteType
-									if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &target); err != nil {
-										return nil, err
-									}
-									return &stubs.SourceDriverConfig{
-										VCSs: map[string]vcsdriver.Config{
-											"test_vcs_driver": target,
-										},
-									}, nil
-								},
-							}
-						},
+						Name:         "test_source_driver_uses_ambiguous_vcs",
+						ConfigLoader: loader,
 					},
 				)
 			},
@@ -294,49 +316,46 @@ var _ = Describe("func Load() (source configuration)", func() {
 			`<dir>/config-0.hcl: the configuration for the 'test_source' source cannot be loaded: cannot expand user-specific home dir`,
 		),
 		Entry(
-			`error normalizing implicit source's driver configuration`,
+			`error producing implicit sources`,
 			[]string{},
-			`the configuration for the implicit 'implicit' source (provided by the 'test_source_driver_with_implicit_source' driver) cannot be loaded: cannot expand user-specific home dir`,
+			`the implicit sources provided by the 'test_source_driver_with_implicit_source' driver cannot be loaded: <error>`,
 			func(reg *registry.Registry) {
-				schema := newSourceStub()
-				schema.FilesystemPath = "~someuser/path/to/nowhere"
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					return nil, errors.New("<error>")
+				}
 
 				reg.RegisterSourceDriver(
 					"test_source_driver_with_implicit_source",
 					sourcedriver.Registration{
-						Name: "test_source_driver",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return newSourceStub()
-						},
-						ImplicitSources: map[string]sourcedriver.ConfigSchema{
-							"implicit": schema,
-						},
+						Name:         "test_source_driver",
+						ConfigLoader: loader,
 					},
 				)
 			},
 		),
 		Entry(
-			`unregocnizzed VCS driver dependency`,
+			`unrecognized VCS driver dependency`,
 			[]string{
 				`source "test_source" "test_source_driver_uses_unrecognized_vcs" {}`,
 			},
-			`<dir>/config-0.hcl: the configuration for the 'test_source' source cannot be loaded: dependency on unrecognized version control system ('<unrecognized>')`,
+			`the implicit sources provided by the 'test_source_driver_uses_unrecognized_vcs' driver cannot be loaded: dependency on unrecognized version control system ('<unrecognized>')`,
 			func(reg *registry.Registry) {
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					target := &stubs.VCSDriverConfig{}
+					return nil, ctx.UnmarshalVCSConfig("<unrecognized>", &target)
+				}
+
 				reg.RegisterSourceDriver(
 					"test_source_driver_uses_unrecognized_vcs",
 					sourcedriver.Registration{
-						Name: "test_source_driver_uses_unrecognized_vcs",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return &stubs.SourceDriverConfigSchema{
-								NormalizeFunc: func(
-									ctx sourcedriver.ConfigContext,
-									s *stubs.SourceDriverConfigSchema,
-								) (sourcedriver.Config, error) {
-									target := &stubs.VCSDriverConfig{}
-									return nil, ctx.UnmarshalVCSConfig("<unrecognized>", &target)
-								},
-							}
-						},
+						Name:         "test_source_driver_uses_unrecognized_vcs",
+						ConfigLoader: loader,
 					},
 				)
 			},
@@ -346,23 +365,21 @@ var _ = Describe("func Load() (source configuration)", func() {
 			[]string{
 				`source "test_source" "test_source_driver_uses_unrecognized_vcs" {}`,
 			},
-			`<dir>/config-0.hcl: the configuration for the 'test_source' source cannot be loaded: depends on incompatible version control system ('test_vcs_driver'), none of the matching drivers ('test_vcs_driver') use the same configuration structure`,
+			`the implicit sources provided by the 'test_source_driver_uses_unrecognized_vcs' driver cannot be loaded: depends on incompatible version control system ('test_vcs_driver'), none of the matching drivers ('test_vcs_driver') use the same configuration structure`,
 			func(reg *registry.Registry) {
+				loader := newSourceLoader()
+				loader.ImplicitSourcesFunc = func(
+					ctx sourcedriver.ConfigContext,
+				) ([]sourcedriver.ImplicitSource, error) {
+					target := aDifferentVCSConfigConcreteType{}
+					return nil, ctx.UnmarshalVCSConfig(testVCSDriverName, &target)
+				}
+
 				reg.RegisterSourceDriver(
 					"test_source_driver_uses_unrecognized_vcs",
 					sourcedriver.Registration{
-						Name: "test_source_driver_uses_unrecognized_vcs",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return &stubs.SourceDriverConfigSchema{
-								NormalizeFunc: func(
-									ctx sourcedriver.ConfigContext,
-									s *stubs.SourceDriverConfigSchema,
-								) (sourcedriver.Config, error) {
-									target := aDifferentVCSConfigConcreteType{}
-									return nil, ctx.UnmarshalVCSConfig(testVCSDriverName, &target)
-								},
-							}
-						},
+						Name:         "test_source_driver_uses_unrecognized_vcs",
+						ConfigLoader: loader,
 					},
 				)
 			},
@@ -373,26 +390,17 @@ var _ = Describe("func Load() (source configuration)", func() {
 		DescribeTable(
 			"it panics",
 			func(target interface{}, expect string) {
-				schema := &stubs.SourceDriverConfigSchema{
-					NormalizeFunc: func(
-						ctx sourcedriver.ConfigContext,
-						s *stubs.SourceDriverConfigSchema,
-					) (sourcedriver.Config, error) {
-						ctx.UnmarshalVCSConfig(testVCSDriverName, target)
-						return nil, nil
-					},
-				}
-
 				reg := &registry.Registry{}
 				reg.RegisterSourceDriver(
 					"test_source_driver",
 					sourcedriver.Registration{
 						Name: "test_source_driver",
-						NewConfigSchema: func() sourcedriver.ConfigSchema {
-							return &stubs.SourceDriverConfigSchema{} // DOUBLE CHECK
-						},
-						ImplicitSources: map[string]sourcedriver.ConfigSchema{
-							"implicit": schema,
+						ConfigLoader: &stubs.SourceDriverConfigLoader{
+							ImplicitSourcesFunc: func(
+								ctx sourcedriver.ConfigContext,
+							) ([]sourcedriver.ImplicitSource, error) {
+								return nil, ctx.UnmarshalVCSConfig(testVCSDriverName, target)
+							},
 						},
 					},
 				)

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -190,9 +190,9 @@ var _ = Describe("func Load() (source configuration)", func() {
 					testVCSDriverName+"_alias",
 					vcsdriver.Registration{
 						Name: testVCSDriverName,
-						ConfigNormalizer: &stubs.VCSDriverConfigNormalizer{
+						ConfigLoader: &stubs.VCSDriverConfigLoader{
 							DefaultsFunc: func(
-								vcsdriver.ConfigNormalizeContext,
+								vcsdriver.ConfigContext,
 							) (vcsdriver.Config, error) {
 								return aDifferentVCSConfigConcreteType{}, nil
 							},

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -389,6 +389,24 @@ var _ = Describe("func Load() (source configuration)", func() {
 				)
 			},
 		),
+		Entry(
+			`configuration for unused VCS driver`,
+			[]string{
+				`source "test_source" "test_source_driver" {
+					vcs "unused_vcs_driver" {}
+				}`,
+			},
+			`<dir>/config-0.hcl: the 'test_source' source has configuration for the 'unused_vcs_driver' version control system but the source driver ('test_source_driver') does not support that VCS`,
+			func(reg *registry.Registry) {
+				reg.RegisterVCSDriver(
+					"unused_vcs_driver",
+					vcsdriver.Registration{
+						Name:         "unused_vcs_driver",
+						ConfigLoader: newVCSLoader(),
+					},
+				)
+			},
+		),
 	)
 
 	When("the source driver uses UnmarshalVCSConfig() incorrectly", func() {

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("func Load() (source configuration)", func() {
 	type aDifferentVCSConfigConcreteType struct {
-		*stubs.VCSDriverConfig
+		*stubs.VCSConfig
 	}
 
 	DescribeTable(
@@ -35,10 +35,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -58,10 +58,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -81,10 +81,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<explicit>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -100,10 +100,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/implicit",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<implicit>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -114,11 +114,11 @@ var _ = Describe("func Load() (source configuration)", func() {
 				loader.ImplicitSourcesFunc = func(
 					ctx sourcedriver.ConfigContext,
 				) ([]sourcedriver.ImplicitSource, error) {
-					cfg := &stubs.SourceDriverConfig{
+					cfg := &stubs.SourceConfig{
 						ArbitraryAttribute: "<implicit>",
 					}
 
-					vcsConfig := &stubs.VCSDriverConfig{}
+					vcsConfig := &stubs.VCSConfig{}
 					if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &vcsConfig); err != nil {
 						return nil, err
 					}
@@ -157,10 +157,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/implicit",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<explicit>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default>",
 						},
 					},
@@ -174,7 +174,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					return []sourcedriver.ImplicitSource{
 						{
 							Name: "implicit",
-							Config: &stubs.SourceDriverConfig{
+							Config: &stubs.SourceConfig{
 								ArbitraryAttribute: "<implicit>",
 							},
 						},
@@ -199,7 +199,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/implicit",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					VCSs: map[string]vcsdriver.Config{
 						testVCSDriverName: aDifferentVCSConfigConcreteType{},
 					},
@@ -212,7 +212,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					testVCSDriverName+"_alias",
 					vcsdriver.Registration{
 						Name: testVCSDriverName,
-						ConfigLoader: &stubs.VCSDriverConfigLoader{
+						ConfigLoader: &stubs.VCSConfigLoader{
 							DefaultsFunc: func(
 								vcsdriver.ConfigContext,
 							) (vcsdriver.Config, error) {
@@ -234,7 +234,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					return []sourcedriver.ImplicitSource{
 						{
 							Name: "implicit",
-							Config: &stubs.SourceDriverConfig{
+							Config: &stubs.SourceConfig{
 								VCSs: map[string]vcsdriver.Config{
 									testVCSDriverName: target,
 								},
@@ -352,7 +352,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 				loader.ImplicitSourcesFunc = func(
 					ctx sourcedriver.ConfigContext,
 				) ([]sourcedriver.ImplicitSource, error) {
-					target := &stubs.VCSDriverConfig{}
+					target := &stubs.VCSConfig{}
 					return nil, ctx.UnmarshalVCSConfig("<unrecognized>", &target)
 				}
 
@@ -400,7 +400,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					"test_source_driver",
 					sourcedriver.Registration{
 						Name: "test_source_driver",
-						ConfigLoader: &stubs.SourceDriverConfigLoader{
+						ConfigLoader: &stubs.SourceConfigLoader{
 							ImplicitSourcesFunc: func(
 								ctx sourcedriver.ConfigContext,
 							) ([]sourcedriver.ImplicitSource, error) {

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -82,7 +82,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					Dir: "~/grit/test_source",
 				},
 				Driver: &stubs.SourceDriverConfig{
-					ArbitraryAttribute: "<default> + <explicit>",
+					ArbitraryAttribute: "<explicit>",
 					VCSs: map[string]vcsdriver.Config{
 						testVCSDriverName: &stubs.VCSDriverConfig{
 							ArbitraryAttribute: "<default>",
@@ -118,8 +118,13 @@ var _ = Describe("func Load() (source configuration)", func() {
 						ArbitraryAttribute: "<implicit>",
 					}
 
-					if err := unmarshalVCSConfig(ctx, cfg, testVCSDriverName); err != nil {
+					vcsConfig := &stubs.VCSDriverConfig{}
+					if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &vcsConfig); err != nil {
 						return nil, err
+					}
+
+					cfg.VCSs = map[string]vcsdriver.Config{
+						testVCSDriverName: vcsConfig,
 					}
 
 					return []sourcedriver.ImplicitSource{
@@ -153,7 +158,7 @@ var _ = Describe("func Load() (source configuration)", func() {
 					Dir: "~/grit/implicit",
 				},
 				Driver: &stubs.SourceDriverConfig{
-					ArbitraryAttribute: "<default> + <explicit>",
+					ArbitraryAttribute: "<explicit>",
 					VCSs: map[string]vcsdriver.Config{
 						testVCSDriverName: &stubs.VCSDriverConfig{
 							ArbitraryAttribute: "<default>",

--- a/config/loadsource_test.go
+++ b/config/loadsource_test.go
@@ -207,11 +207,11 @@ var _ = Describe("func Load() (source configuration)", func() {
 						NewConfigSchema: func() sourcedriver.ConfigSchema {
 							return &stubs.SourceDriverConfigSchema{
 								NormalizeFunc: func(
-									nc sourcedriver.ConfigNormalizeContext,
+									ctx sourcedriver.ConfigContext,
 									s *stubs.SourceDriverConfigSchema,
 								) (sourcedriver.Config, error) {
 									var target aDifferentVCSConfigConcreteType
-									if err := nc.UnmarshalVCSConfig(testVCSDriverName, &target); err != nil {
+									if err := ctx.UnmarshalVCSConfig(testVCSDriverName, &target); err != nil {
 										return nil, err
 									}
 									return &stubs.SourceDriverConfig{
@@ -329,11 +329,11 @@ var _ = Describe("func Load() (source configuration)", func() {
 						NewConfigSchema: func() sourcedriver.ConfigSchema {
 							return &stubs.SourceDriverConfigSchema{
 								NormalizeFunc: func(
-									nc sourcedriver.ConfigNormalizeContext,
+									ctx sourcedriver.ConfigContext,
 									s *stubs.SourceDriverConfigSchema,
 								) (sourcedriver.Config, error) {
 									target := &stubs.VCSDriverConfig{}
-									return nil, nc.UnmarshalVCSConfig("<unrecognized>", &target)
+									return nil, ctx.UnmarshalVCSConfig("<unrecognized>", &target)
 								},
 							}
 						},
@@ -355,11 +355,11 @@ var _ = Describe("func Load() (source configuration)", func() {
 						NewConfigSchema: func() sourcedriver.ConfigSchema {
 							return &stubs.SourceDriverConfigSchema{
 								NormalizeFunc: func(
-									nc sourcedriver.ConfigNormalizeContext,
+									ctx sourcedriver.ConfigContext,
 									s *stubs.SourceDriverConfigSchema,
 								) (sourcedriver.Config, error) {
 									target := aDifferentVCSConfigConcreteType{}
-									return nil, nc.UnmarshalVCSConfig(testVCSDriverName, &target)
+									return nil, ctx.UnmarshalVCSConfig(testVCSDriverName, &target)
 								},
 							}
 						},
@@ -375,10 +375,10 @@ var _ = Describe("func Load() (source configuration)", func() {
 			func(target interface{}, expect string) {
 				schema := &stubs.SourceDriverConfigSchema{
 					NormalizeFunc: func(
-						nc sourcedriver.ConfigNormalizeContext,
+						ctx sourcedriver.ConfigContext,
 						s *stubs.SourceDriverConfigSchema,
 					) (sourcedriver.Config, error) {
-						nc.UnmarshalVCSConfig(testVCSDriverName, target)
+						ctx.UnmarshalVCSConfig(testVCSDriverName, target)
 						return nil, nil
 					},
 				}

--- a/config/loadvcs.go
+++ b/config/loadvcs.go
@@ -168,10 +168,10 @@ type vcsContext struct {
 	loader *loader
 }
 
-func (nc *vcsContext) EvalContext() *hcl.EvalContext {
+func (c *vcsContext) EvalContext() *hcl.EvalContext {
 	return &hcl.EvalContext{}
 }
 
-func (nc *vcsContext) NormalizePath(p *string) error {
-	return nc.loader.normalizePath(p)
+func (c *vcsContext) NormalizePath(p *string) error {
+	return c.loader.normalizePath(p)
 }

--- a/config/loadvcs.go
+++ b/config/loadvcs.go
@@ -32,11 +32,10 @@ func (l *loader) mergeGlobalVCS(file string, s vcsSchema) error {
 		)
 	}
 
-	lowerName := strings.ToLower(s.Driver)
 	ctx := &vcsContext{l}
 	cfg, err := reg.ConfigLoader.UnmarshalAndMerge(
 		ctx,
-		l.defaultVCSs[lowerName],
+		l.defaultVCSs[s.Driver],
 		s.DriverBody,
 	)
 	if err != nil {

--- a/config/loadvcs.go
+++ b/config/loadvcs.go
@@ -32,9 +32,8 @@ func (l *loader) mergeGlobalVCS(file string, s vcsSchema) error {
 		)
 	}
 
-	nc := &vcsNormalizeContext{l}
-
-	cfg, err := reg.ConfigNormalizer.Defaults(nc)
+	ctx := &vcsContext{l}
+	cfg, err := reg.ConfigLoader.Defaults(ctx)
 	if err != nil {
 		if isHCLError(err) {
 			return err
@@ -47,8 +46,8 @@ func (l *loader) mergeGlobalVCS(file string, s vcsSchema) error {
 		)
 	}
 
-	cfg, err = reg.ConfigNormalizer.Merge(
-		nc,
+	cfg, err = reg.ConfigLoader.Merge(
+		ctx,
 		cfg,
 		s.DriverBody,
 	)
@@ -87,8 +86,8 @@ func (l *loader) populateImplicitGlobalVCSs() error {
 			continue
 		}
 
-		nc := &vcsNormalizeContext{l}
-		cfg, err := reg.ConfigNormalizer.Defaults(nc)
+		ctx := &vcsContext{l}
+		cfg, err := reg.ConfigLoader.Defaults(ctx)
 		if err != nil {
 			return fmt.Errorf(
 				"unable to produce default global configuration for the '%s' version control system: %w",
@@ -143,8 +142,8 @@ func (l *loader) finalizeSourceSpecificVCSs(
 			)
 		}
 
-		nc := &vcsNormalizeContext{l}
-		cfg, err := reg.ConfigNormalizer.Merge(nc, l.globalVCSs[driver], body)
+		ctx := &vcsContext{l}
+		cfg, err := reg.ConfigLoader.Merge(ctx, l.globalVCSs[driver], body)
 		if err != nil {
 			if isHCLError(err) {
 				return nil, err
@@ -164,16 +163,15 @@ func (l *loader) finalizeSourceSpecificVCSs(
 	return configs, nil
 }
 
-// vcsNormalizeContext is an implementation of the
-// vcsdriver.ConfigNormalizeContext interface.
-type vcsNormalizeContext struct {
+// vcsContext is an implementation of the vcsdriver.ConfigContext interface.
+type vcsContext struct {
 	loader *loader
 }
 
-func (nc *vcsNormalizeContext) EvalContext() *hcl.EvalContext {
+func (nc *vcsContext) EvalContext() *hcl.EvalContext {
 	return &hcl.EvalContext{}
 }
 
-func (nc *vcsNormalizeContext) NormalizePath(p *string) error {
+func (nc *vcsContext) NormalizePath(p *string) error {
 	return nc.loader.normalizePath(p)
 }

--- a/config/loadvcs.go
+++ b/config/loadvcs.go
@@ -34,7 +34,7 @@ func (l *loader) mergeGlobalVCS(file string, s vcsSchema) error {
 
 	lowerName := strings.ToLower(s.Driver)
 	ctx := &vcsContext{l}
-	cfg, err := reg.ConfigLoader.Merge(
+	cfg, err := reg.ConfigLoader.UnmarshalAndMerge(
 		ctx,
 		l.defaultVCSs[lowerName],
 		s.DriverBody,
@@ -130,7 +130,7 @@ func (l *loader) finalizeSourceSpecificVCSs(
 		}
 
 		ctx := &vcsContext{l}
-		cfg, err := reg.ConfigLoader.Merge(ctx, cfg, body)
+		cfg, err := reg.ConfigLoader.UnmarshalAndMerge(ctx, cfg, body)
 		if err != nil {
 			if isHCLError(err) {
 				return nil, err

--- a/config/loadvcs_test.go
+++ b/config/loadvcs_test.go
@@ -148,9 +148,9 @@ var _ = Describe("func Load() (VCS configuration)", func() {
 					"test_vcs_driver_with_broken_default",
 					vcsdriver.Registration{
 						Name: testVCSDriverName,
-						ConfigNormalizer: &stubs.VCSDriverConfigNormalizer{
+						ConfigLoader: &stubs.VCSDriverConfigLoader{
 							DefaultsFunc: func(
-								vcsdriver.ConfigNormalizeContext,
+								vcsdriver.ConfigContext,
 							) (vcsdriver.Config, error) {
 								return nil, errors.New("<error>")
 							},

--- a/config/loadvcs_test.go
+++ b/config/loadvcs_test.go
@@ -30,10 +30,10 @@ var _ = Describe("func Load() (VCS configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default> + <explicit>",
 						},
 					},
@@ -55,10 +55,10 @@ var _ = Describe("func Load() (VCS configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default> + <explicit>",
 						},
 					},
@@ -84,10 +84,10 @@ var _ = Describe("func Load() (VCS configuration)", func() {
 				Clones: Clones{
 					Dir: "~/grit/test_source",
 				},
-				Driver: &stubs.SourceDriverConfig{
+				Driver: &stubs.SourceConfig{
 					ArbitraryAttribute: "<default>",
 					VCSs: map[string]vcsdriver.Config{
-						testVCSDriverName: &stubs.VCSDriverConfig{
+						testVCSDriverName: &stubs.VCSConfig{
 							ArbitraryAttribute: "<default> + <explicit global> + <override>",
 						},
 					},
@@ -148,7 +148,7 @@ var _ = Describe("func Load() (VCS configuration)", func() {
 					"test_vcs_driver_with_broken_default",
 					vcsdriver.Registration{
 						Name: testVCSDriverName,
-						ConfigLoader: &stubs.VCSDriverConfigLoader{
+						ConfigLoader: &stubs.VCSConfigLoader{
 							DefaultsFunc: func(
 								vcsdriver.ConfigContext,
 							) (vcsdriver.Config, error) {

--- a/driver/configtest/vcs.go
+++ b/driver/configtest/vcs.go
@@ -151,15 +151,8 @@ type vcsTestSourceConfigLoader struct {
 	unmarshalTarget interface{}
 }
 
-func (l vcsTestSourceConfigLoader) Defaults(
+func (l vcsTestSourceConfigLoader) Unmarshal(
 	ctx sourcedriver.ConfigContext,
-) (sourcedriver.Config, error) {
-	return vcsTestSourceConfig{}, nil
-}
-
-func (l vcsTestSourceConfigLoader) Merge(
-	ctx sourcedriver.ConfigContext,
-	c sourcedriver.Config,
 	b hcl.Body,
 ) (sourcedriver.Config, error) {
 	if err := ctx.UnmarshalVCSConfig(

--- a/driver/configtest/vcs.go
+++ b/driver/configtest/vcs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gritcli/grit/driver/registry"
 	"github.com/gritcli/grit/driver/sourcedriver"
 	"github.com/gritcli/grit/driver/vcsdriver"
+	"github.com/hashicorp/hcl/v2"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/gomega"
@@ -37,13 +38,11 @@ func TestVCSDriver(
 				"driver_under_test",
 				sourcedriver.Registration{
 					Name: "driver_under_test",
-					NewConfigSchema: func() sourcedriver.ConfigSchema {
-						return &vcsTestSourceConfigSchema{
-							driverName: r.Name,
-							unmarshalTarget: reflect.New(
-								reflect.TypeOf(zero),
-							).Interface(),
-						}
+					ConfigLoader: &vcsTestSourceConfigLoader{
+						driverName: r.Name,
+						unmarshalTarget: reflect.New(
+							reflect.TypeOf(zero),
+						).Interface(),
 					},
 				},
 			)
@@ -147,27 +146,41 @@ func VCSFailure(
 	)
 }
 
-type vcsTestSourceConfigSchema struct {
+type vcsTestSourceConfigLoader struct {
 	driverName      string
 	unmarshalTarget interface{}
 }
 
-func (s *vcsTestSourceConfigSchema) Normalize(
+func (l vcsTestSourceConfigLoader) Defaults(
 	ctx sourcedriver.ConfigContext,
 ) (sourcedriver.Config, error) {
+	return vcsTestSourceConfig{}, nil
+}
+
+func (l vcsTestSourceConfigLoader) Merge(
+	ctx sourcedriver.ConfigContext,
+	c sourcedriver.Config,
+	b hcl.Body,
+) (sourcedriver.Config, error) {
 	if err := ctx.UnmarshalVCSConfig(
-		s.driverName,
-		s.unmarshalTarget,
+		l.driverName,
+		l.unmarshalTarget,
 	); err != nil {
 		return nil, err
 	}
 
 	return vcsTestSourceConfig{
 		VCSConfig: reflect.
-			ValueOf(s.unmarshalTarget).
+			ValueOf(l.unmarshalTarget).
 			Elem().
 			Interface().(vcsdriver.Config),
 	}, nil
+}
+
+func (l vcsTestSourceConfigLoader) ImplicitSources(
+	ctx sourcedriver.ConfigContext,
+) ([]sourcedriver.ImplicitSource, error) {
+	return nil, nil
 }
 
 type vcsTestSourceConfig struct {

--- a/driver/configtest/vcs.go
+++ b/driver/configtest/vcs.go
@@ -153,9 +153,9 @@ type vcsTestSourceConfigSchema struct {
 }
 
 func (s *vcsTestSourceConfigSchema) Normalize(
-	nc sourcedriver.ConfigNormalizeContext,
+	ctx sourcedriver.ConfigContext,
 ) (sourcedriver.Config, error) {
-	if err := nc.UnmarshalVCSConfig(
+	if err := ctx.UnmarshalVCSConfig(
 		s.driverName,
 		s.unmarshalTarget,
 	); err != nil {

--- a/driver/sourcedriver/config.go
+++ b/driver/sourcedriver/config.go
@@ -17,16 +17,8 @@ type ImplicitSource struct {
 
 // ConfigLoader is an interface for loading driver-specific source configuration.
 type ConfigLoader interface {
-	// Defaults returns the default configuration to use for a source that uses
-	// this driver.
-	Defaults(ctx ConfigContext) (Config, error)
-
-	// Merge returns a configuration that is the result of merging an existing
-	// configuration with the contents of a "source" block.
-	//
-	// c is the existing configuration, b is the body of the "source" block. c
-	// must not be modified.
-	Merge(ctx ConfigContext, c Config, b hcl.Body) (Config, error)
+	// Unmarshal unmarshals the contents of a "source" block.
+	Unmarshal(ctx ConfigContext, b hcl.Body) (Config, error)
 
 	// ImplicitSources returns the configuration to use for "implicit" sources
 	// provided by this driver without explicit configuration.

--- a/driver/sourcedriver/config.go
+++ b/driver/sourcedriver/config.go
@@ -1,5 +1,7 @@
 package sourcedriver
 
+import "github.com/hashicorp/hcl/v2"
+
 // ConfigSchema is an interface for parsing driver-specific configuration within
 // a "source" block in a Grit configuration file.
 //
@@ -16,14 +18,17 @@ type ConfigSchema interface {
 	//
 	// The implementation must call ctx.ReadVCSConfig() for each VCS driver
 	// that is supported, even if they are not currently in use.
-	Normalize(ctx ConfigNormalizeContext) (Config, error)
+	Normalize(ctx ConfigContext) (Config, error)
 }
 
-// ConfigNormalizeContext provides operations used to normalize a
-// ConfigSchema.
-type ConfigNormalizeContext interface {
-	// NormalizePath normalizes a filesystem encountered within the
-	// configuration.
+// ConfigContext provides operations used when loading source configuration.
+type ConfigContext interface {
+	// EvalContext returns the HCL evaluation context to be used when to
+	// decoding HCL content.
+	EvalContext() *hcl.EvalContext
+
+	// NormalizePath resolves a (potentially relative) filesystem path to an
+	// absolute path.
 	//
 	// If *p begins with a tilde (~), it is resolved relative to the user's home
 	// directory.

--- a/driver/sourcedriver/registration.go
+++ b/driver/sourcedriver/registration.go
@@ -10,10 +10,6 @@ type Registration struct {
 	// Description is a short human-readable description of the driver.
 	Description string
 
-	// NewConfigSchema returns a zero-value ConfigSchema for this driver.
-	NewConfigSchema func() ConfigSchema
-
-	// ImplicitSources is a set of sources that should be added to the
-	// configuration automatically.
-	ImplicitSources map[string]ConfigSchema
+	// ConfigLoader loads configuration for this driver.
+	ConfigLoader ConfigLoader
 }

--- a/driver/vcsdriver/config.go
+++ b/driver/vcsdriver/config.go
@@ -2,29 +2,27 @@ package vcsdriver
 
 import "github.com/hashicorp/hcl/v2"
 
-// ConfigNormalizer is an interface for normalizing driver-specific
-// configuration within a "vcs" block in a Grit configuration file.
-type ConfigNormalizer interface {
-	// Defaults returns the default configuration to use for this driver.
-	Defaults(nc ConfigNormalizeContext) (Config, error)
+// ConfigLoader is an interface for loading driver-specific VCS configuration.
+type ConfigLoader interface {
+	// Defaults returns the default configuration for this driver.
+	Defaults(ctx ConfigContext) (Config, error)
 
-	// Merge returns a new Config that is the result of merging an existing
-	// Config with the contents of a "vcs" block.
+	// Merge returns a configuration that is the result of merging an existing
+	// configuration with the contents of a "vcs" block.
 	//
 	// c is the existing configuration, b is the body of the "vcs" block. c must
 	// not be modified.
-	Merge(nc ConfigNormalizeContext, c Config, b hcl.Body) (Config, error)
+	Merge(ctx ConfigContext, c Config, b hcl.Body) (Config, error)
 }
 
-// ConfigNormalizeContext provides operations used to normalize a
-// ConfigSchema.
-type ConfigNormalizeContext interface {
+// ConfigContext provides operations used when loading VCS configuration.
+type ConfigContext interface {
 	// EvalContext returns the HCL evaluation context to be used when to
 	// decoding HCL content.
 	EvalContext() *hcl.EvalContext
 
-	// NormalizePath normalizes a filesystem encountered within the
-	// configuration.
+	// NormalizePath resolves a (potentially relative) filesystem path to an
+	// absolute path.
 	//
 	// If *p begins with a tilde (~), it is resolved relative to the user's home
 	// directory.
@@ -37,9 +35,9 @@ type ConfigNormalizeContext interface {
 	NormalizePath(p *string) error
 }
 
-// Config is an interface for driver-specific configuration options for a VCS.
+// Config is a driver-specific VCS configuration.
 //
-// The underlying implementation must not be used by more than one driver.
+// The underlying implementation must not be used by more than one VCS driver.
 type Config interface {
 	// DescribeVCSConfig returns a human-readable description of the
 	// configuration.

--- a/driver/vcsdriver/config.go
+++ b/driver/vcsdriver/config.go
@@ -7,12 +7,12 @@ type ConfigLoader interface {
 	// Defaults returns the default configuration for this driver.
 	Defaults(ctx ConfigContext) (Config, error)
 
-	// Merge returns a configuration that is the result of merging an existing
-	// configuration with the contents of a "vcs" block.
+	// UnmarshalAndMerge unmarshals the contents of a "vcs" block and returns
+	// the result of merging it with an existing configuration.
 	//
 	// c is the existing configuration, b is the body of the "vcs" block. c must
 	// not be modified.
-	Merge(ctx ConfigContext, c Config, b hcl.Body) (Config, error)
+	UnmarshalAndMerge(ctx ConfigContext, c Config, b hcl.Body) (Config, error)
 }
 
 // ConfigContext provides operations used when loading VCS configuration.

--- a/driver/vcsdriver/registration.go
+++ b/driver/vcsdriver/registration.go
@@ -10,7 +10,6 @@ type Registration struct {
 	// Description is a short human-readable description of the driver.
 	Description string
 
-	// ConfigNormalizer is the normalizer used to produce configuration values
-	// for this driver.
-	ConfigNormalizer ConfigNormalizer
+	// ConfigLoader loads configuration for this driver.
+	ConfigLoader ConfigLoader
 }

--- a/internal/daemon/internal/source/list_test.go
+++ b/internal/daemon/internal/source/list_test.go
@@ -23,7 +23,7 @@ var _ = Describe("type List", func() {
 					Clones: config.Clones{
 						Dir: "/path/to/clones",
 					},
-					Driver: &stubs.SourceDriverConfig{
+					Driver: &stubs.SourceConfig{
 						NewDriverFunc: func() sourcedriver.Driver {
 							return d
 						},
@@ -47,17 +47,17 @@ var _ = Describe("type List", func() {
 				{
 					Name:    "<b>",
 					Enabled: true,
-					Driver:  &stubs.SourceDriverConfig{},
+					Driver:  &stubs.SourceConfig{},
 				},
 				{
 					Name:    "<c>",
 					Enabled: true,
-					Driver:  &stubs.SourceDriverConfig{},
+					Driver:  &stubs.SourceConfig{},
 				},
 				{
 					Name:    "<a>",
 					Enabled: true,
-					Driver:  &stubs.SourceDriverConfig{},
+					Driver:  &stubs.SourceConfig{},
 				},
 			})
 

--- a/internal/stubs/sourcedriver.go
+++ b/internal/stubs/sourcedriver.go
@@ -12,7 +12,7 @@ import (
 // SourceDriverConfigSchema is a test implementation of
 // sourcedriver.ConfigSchema.
 type SourceDriverConfigSchema struct {
-	NormalizeFunc func(sourcedriver.ConfigNormalizeContext, *SourceDriverConfigSchema) (sourcedriver.Config, error)
+	NormalizeFunc func(sourcedriver.ConfigContext, *SourceDriverConfigSchema) (sourcedriver.Config, error)
 
 	// These attributes must be defined in _this_ struct in order to use it as
 	// the HCL schema.
@@ -24,10 +24,10 @@ type SourceDriverConfigSchema struct {
 // Normalize returns s.NormalizeFunc() if it is non-nil, otherwise returns a
 // new SourceDriverConfig stub.
 func (s *SourceDriverConfigSchema) Normalize(
-	nc sourcedriver.ConfigNormalizeContext,
+	ctx sourcedriver.ConfigContext,
 ) (sourcedriver.Config, error) {
 	if s.NormalizeFunc != nil {
-		return s.NormalizeFunc(nc, s)
+		return s.NormalizeFunc(ctx, s)
 	}
 
 	return &SourceDriverConfig{}, nil

--- a/internal/stubs/sourcedriver.go
+++ b/internal/stubs/sourcedriver.go
@@ -10,16 +10,15 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-// SourceDriverConfigLoader is a test implementation of
-// sourcedriver.ConfigLoader.
-type SourceDriverConfigLoader struct {
+// SourceConfigLoader is a test implementation of sourcedriver.ConfigLoader.
+type SourceConfigLoader struct {
 	UnmarshalFunc       func(sourcedriver.ConfigContext, hcl.Body) (sourcedriver.Config, error)
 	ImplicitSourcesFunc func(sourcedriver.ConfigContext) ([]sourcedriver.ImplicitSource, error)
 }
 
 // Unmarshal returns s.UnmarshalFunc() if it is non-nil; otherwise, it returns
 // an error.
-func (s *SourceDriverConfigLoader) Unmarshal(
+func (s *SourceConfigLoader) Unmarshal(
 	ctx sourcedriver.ConfigContext,
 	b hcl.Body,
 ) (sourcedriver.Config, error) {
@@ -32,7 +31,7 @@ func (s *SourceDriverConfigLoader) Unmarshal(
 
 // ImplicitSources returns s.ImplicitSourcesFunc() if it is non-nil; otherwise,
 // it returns (nil, nil).
-func (s *SourceDriverConfigLoader) ImplicitSources(
+func (s *SourceConfigLoader) ImplicitSources(
 	ctx sourcedriver.ConfigContext,
 ) ([]sourcedriver.ImplicitSource, error) {
 	if s.ImplicitSourcesFunc != nil {
@@ -42,15 +41,14 @@ func (s *SourceDriverConfigLoader) ImplicitSources(
 	return nil, nil
 }
 
-// SourceDriverConfigSchema is the HCL schema for SourceDriverConfig.
-type SourceDriverConfigSchema struct {
+// SourceConfigSchema is the HCL schema for SourceConfig.
+type SourceConfigSchema struct {
 	ArbitraryAttribute string `hcl:"arbitrary_attribute,optional"`
 	FilesystemPath     string `hcl:"filesystem_path,optional"`
 }
 
-// SourceDriverConfig is a test implementation of the sourcedriver.Config
-// interface.
-type SourceDriverConfig struct {
+// SourceConfig is a test implementation of the sourcedriver.Config interface.
+type SourceConfig struct {
 	NewDriverFunc            func() sourcedriver.Driver
 	DescribeSourceConfigFunc func() string
 
@@ -61,7 +59,7 @@ type SourceDriverConfig struct {
 
 // NewDriver returns s.NewDriverFunc() if it is non-nil; otherwise, it returns a
 // new SourceDriver stub.
-func (s *SourceDriverConfig) NewDriver() sourcedriver.Driver {
+func (s *SourceConfig) NewDriver() sourcedriver.Driver {
 	if s.NewDriverFunc != nil {
 		return s.NewDriverFunc()
 	}
@@ -71,7 +69,7 @@ func (s *SourceDriverConfig) NewDriver() sourcedriver.Driver {
 
 // DescribeSourceConfig returns s.DescribeSourceConfigFunc() if it is non-nil;
 // otherwise, it returns a new fixed value.
-func (s *SourceDriverConfig) DescribeSourceConfig() string {
+func (s *SourceConfig) DescribeSourceConfig() string {
 	if s.DescribeSourceConfigFunc != nil {
 		return s.DescribeSourceConfigFunc()
 	}

--- a/internal/stubs/sourcedriver.go
+++ b/internal/stubs/sourcedriver.go
@@ -13,31 +13,18 @@ import (
 // SourceDriverConfigLoader is a test implementation of
 // sourcedriver.ConfigLoader.
 type SourceDriverConfigLoader struct {
-	DefaultsFunc        func(sourcedriver.ConfigContext) (sourcedriver.Config, error)
-	MergeFunc           func(sourcedriver.ConfigContext, sourcedriver.Config, hcl.Body) (sourcedriver.Config, error)
+	UnmarshalFunc       func(sourcedriver.ConfigContext, hcl.Body) (sourcedriver.Config, error)
 	ImplicitSourcesFunc func(sourcedriver.ConfigContext) ([]sourcedriver.ImplicitSource, error)
 }
 
-// Defaults returns s.DefaultsFunc() if it is non-nil; otherwise, it returns an
-// error.
-func (s *SourceDriverConfigLoader) Defaults(
+// Unmarshal returns s.UnmarshalFunc() if it is non-nil; otherwise, it returns
+// an error.
+func (s *SourceDriverConfigLoader) Unmarshal(
 	ctx sourcedriver.ConfigContext,
-) (sourcedriver.Config, error) {
-	if s.DefaultsFunc != nil {
-		return s.DefaultsFunc(ctx)
-	}
-
-	return nil, errors.New("<not implemented>")
-}
-
-// Merge returns s.MergeFunc() if it is non-nil; otherwise, it returns an error.
-func (s *SourceDriverConfigLoader) Merge(
-	ctx sourcedriver.ConfigContext,
-	c sourcedriver.Config,
 	b hcl.Body,
 ) (sourcedriver.Config, error) {
-	if s.MergeFunc != nil {
-		return s.MergeFunc(ctx, c, b)
+	if s.UnmarshalFunc != nil {
+		return s.UnmarshalFunc(ctx, b)
 	}
 
 	return nil, errors.New("<not implemented>")

--- a/internal/stubs/vcsdriver.go
+++ b/internal/stubs/vcsdriver.go
@@ -7,15 +7,15 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-// VCSDriverConfigLoader is a test implementation of vcsdriver.ConfigLoader.
-type VCSDriverConfigLoader struct {
+// VCSConfigLoader is a test implementation of vcsdriver.ConfigLoader.
+type VCSConfigLoader struct {
 	DefaultsFunc          func(vcsdriver.ConfigContext) (vcsdriver.Config, error)
 	UnmarshalAndMergeFunc func(vcsdriver.ConfigContext, vcsdriver.Config, hcl.Body) (vcsdriver.Config, error)
 }
 
 // Defaults returns s.DefaultsFunc() if it is non-nil; otherwise, it returns an
 // error.
-func (s *VCSDriverConfigLoader) Defaults(
+func (s *VCSConfigLoader) Defaults(
 	ctx vcsdriver.ConfigContext,
 ) (vcsdriver.Config, error) {
 	if s.DefaultsFunc != nil {
@@ -27,7 +27,7 @@ func (s *VCSDriverConfigLoader) Defaults(
 
 // UnmarshalAndMerge returns s.MergeFunc() if it is non-nil; otherwise, it
 // returns an error.
-func (s *VCSDriverConfigLoader) UnmarshalAndMerge(
+func (s *VCSConfigLoader) UnmarshalAndMerge(
 	ctx vcsdriver.ConfigContext,
 	c vcsdriver.Config,
 	b hcl.Body,
@@ -39,14 +39,14 @@ func (s *VCSDriverConfigLoader) UnmarshalAndMerge(
 	return nil, errors.New("<not implemented>")
 }
 
-// VCSDriverConfigSchema is the HCL schema for VCSConfig.
-type VCSDriverConfigSchema struct {
+// VCSConfigSchema is the HCL schema for VCSConfig.
+type VCSConfigSchema struct {
 	ArbitraryAttribute string `hcl:"arbitrary_attribute,optional"`
 	FilesystemPath     string `hcl:"filesystem_path,optional"`
 }
 
-// VCSDriverConfig is a test implementation of vcsdriver.Config.
-type VCSDriverConfig struct {
+// VCSConfig is a test implementation of vcsdriver.Config.
+type VCSConfig struct {
 	DescribeVCSConfigFunc func() string
 
 	ArbitraryAttribute string
@@ -55,7 +55,7 @@ type VCSDriverConfig struct {
 
 // DescribeVCSConfig returns s.DescribeVCSConfigFunc() if it is non-nil;
 // otherwise, it returns a new fixed value.
-func (s *VCSDriverConfig) DescribeVCSConfig() string {
+func (s *VCSConfig) DescribeVCSConfig() string {
 	if s.DescribeVCSConfigFunc != nil {
 		return s.DescribeVCSConfigFunc()
 	}

--- a/internal/stubs/vcsdriver.go
+++ b/internal/stubs/vcsdriver.go
@@ -7,72 +7,41 @@ import (
 	"github.com/hashicorp/hcl/v2"
 )
 
-// VCSDriverConfigSchema is a test implementation of vcsdriver.ConfigSchema.
-type VCSDriverConfigSchema struct {
-	NormalizeGlobalsFunc        func(vcsdriver.ConfigNormalizeContext, *VCSDriverConfigSchema) (vcsdriver.Config, error)
-	NormalizeSourceSpecificFunc func(vcsdriver.ConfigNormalizeContext, vcsdriver.Config, *VCSDriverConfigSchema) (vcsdriver.Config, error)
-
-	// These attributes must be defined in _this_ struct in order to use it as
-	// the HCL schema.
-
-	ArbitraryAttribute string `hcl:"arbitrary_attribute,optional"`
-	FilesystemPath     string `hcl:"filesystem_path,optional"`
-}
-
-// NormalizeGlobals returns s.NormalizeGlobalsFunc() if it is non-nil, otherwise
-// returns a new VCSDriverConfig stub.
-func (s *VCSDriverConfigSchema) NormalizeGlobals(
-	nc vcsdriver.ConfigNormalizeContext,
-) (vcsdriver.Config, error) {
-	if s.NormalizeGlobalsFunc != nil {
-		return s.NormalizeGlobalsFunc(nc, s)
-	}
-
-	return &VCSDriverConfig{}, nil
-}
-
-// NormalizeSourceSpecific returns s.NormalizeSourceSpecificFunc() if it is
-// non-nil, otherwise returns g.
-func (s *VCSDriverConfigSchema) NormalizeSourceSpecific(
-	nc vcsdriver.ConfigNormalizeContext,
-	g vcsdriver.Config,
-) (vcsdriver.Config, error) {
-	if s.NormalizeSourceSpecificFunc != nil {
-		return s.NormalizeSourceSpecificFunc(nc, g, s)
-	}
-
-	return g, nil
-}
-
-// VCSDriverConfigNormalizer is a test implementation of vcsdriver.ConfigNormalizer.
-type VCSDriverConfigNormalizer struct {
-	DefaultsFunc func(vcsdriver.ConfigNormalizeContext) (vcsdriver.Config, error)
-	MergeFunc    func(vcsdriver.ConfigNormalizeContext, vcsdriver.Config, hcl.Body) (vcsdriver.Config, error)
+// VCSDriverConfigLoader is a test implementation of vcsdriver.ConfigLoader.
+type VCSDriverConfigLoader struct {
+	DefaultsFunc func(vcsdriver.ConfigContext) (vcsdriver.Config, error)
+	MergeFunc    func(vcsdriver.ConfigContext, vcsdriver.Config, hcl.Body) (vcsdriver.Config, error)
 }
 
 // Defaults returns s.DefaultsFunc() if it is non-nil; otherwise, it returns an
 // error.
-func (s *VCSDriverConfigNormalizer) Defaults(
-	nc vcsdriver.ConfigNormalizeContext,
+func (s *VCSDriverConfigLoader) Defaults(
+	ctx vcsdriver.ConfigContext,
 ) (vcsdriver.Config, error) {
 	if s.DefaultsFunc != nil {
-		return s.DefaultsFunc(nc)
+		return s.DefaultsFunc(ctx)
 	}
 
 	return nil, errors.New("<not implemented>")
 }
 
 // Merge returns s.MergeFunc() if it is non-nil; otherwise, it returns an error.
-func (s *VCSDriverConfigNormalizer) Merge(
-	nc vcsdriver.ConfigNormalizeContext,
+func (s *VCSDriverConfigLoader) Merge(
+	ctx vcsdriver.ConfigContext,
 	c vcsdriver.Config,
 	b hcl.Body,
 ) (vcsdriver.Config, error) {
 	if s.MergeFunc != nil {
-		return s.MergeFunc(nc, c, b)
+		return s.MergeFunc(ctx, c, b)
 	}
 
 	return nil, errors.New("<not implemented>")
+}
+
+// VCSDriverConfigSchema is the HCL schema for VCSConfig.
+type VCSDriverConfigSchema struct {
+	ArbitraryAttribute string `hcl:"arbitrary_attribute,optional"`
+	FilesystemPath     string `hcl:"filesystem_path,optional"`
 }
 
 // VCSDriverConfig is a test implementation of vcsdriver.Config.

--- a/internal/stubs/vcsdriver.go
+++ b/internal/stubs/vcsdriver.go
@@ -9,8 +9,8 @@ import (
 
 // VCSDriverConfigLoader is a test implementation of vcsdriver.ConfigLoader.
 type VCSDriverConfigLoader struct {
-	DefaultsFunc func(vcsdriver.ConfigContext) (vcsdriver.Config, error)
-	MergeFunc    func(vcsdriver.ConfigContext, vcsdriver.Config, hcl.Body) (vcsdriver.Config, error)
+	DefaultsFunc          func(vcsdriver.ConfigContext) (vcsdriver.Config, error)
+	UnmarshalAndMergeFunc func(vcsdriver.ConfigContext, vcsdriver.Config, hcl.Body) (vcsdriver.Config, error)
 }
 
 // Defaults returns s.DefaultsFunc() if it is non-nil; otherwise, it returns an
@@ -25,14 +25,15 @@ func (s *VCSDriverConfigLoader) Defaults(
 	return nil, errors.New("<not implemented>")
 }
 
-// Merge returns s.MergeFunc() if it is non-nil; otherwise, it returns an error.
-func (s *VCSDriverConfigLoader) Merge(
+// UnmarshalAndMerge returns s.MergeFunc() if it is non-nil; otherwise, it
+// returns an error.
+func (s *VCSDriverConfigLoader) UnmarshalAndMerge(
 	ctx vcsdriver.ConfigContext,
 	c vcsdriver.Config,
 	b hcl.Body,
 ) (vcsdriver.Config, error) {
-	if s.MergeFunc != nil {
-		return s.MergeFunc(ctx, c, b)
+	if s.UnmarshalAndMergeFunc != nil {
+		return s.UnmarshalAndMergeFunc(ctx, c, b)
 	}
 
 	return nil, errors.New("<not implemented>")


### PR DESCRIPTION
Instead of requiring that the driver provider a HCL schema that is compatible with the `gohcl` package, they are simply passed an `hcl.Body` that the implementation can unmarshal however appropriate. This allows use of the lower-level HCL APIs.

Also fixes #42.